### PR TITLE
Taxonomy term split

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,20 @@ Delete taxonomy term (including all its childrens) ::
     curl -X DELETE \
       http://localhost:5000/taxonomies/<taxonomy-code>/<taxonomy-term-path>/
 
-Move taxonony (or whole subtree) to another tree (identified by slug) ::
+Update taxonomy extra data ::
 
-    curl -X POST \
-        http://localhost:5000/taxonomies/vehicle/land-vehicle/car/move \
-        -d '{"destination":"road-vehicle"}'
+    curl -X PATCH \
+        http://localhost:5000/taxonomies/<taxonomy-code>/ \
+        -d '{"extra_data":"{...}"}'
+
+Update taxonomy term data ::
+
+    curl -X PATCH \
+        http://localhost:5000/taxonomies/<taxonomy-code>/<taxonomy-term-path>/ \
+        -d '{"title":"{...}", "extra_data":"{...}"}'
+
+Move taxonomy term (or whole term subtree) to another location ::
+
+    curl -X PATCH \
+        http://localhost:5000/taxonomies/<taxonomy-code>/<taxonomy-term-path>/ \
+        -d '{"move_target":"/<target-taxonomy-code>/<target-taxonomy-term-path>/"}'

--- a/README.rst
+++ b/README.rst
@@ -45,42 +45,66 @@ To deploy::
 In your production environment, make sure the ``FLASK_DEBUG`` environment
 variable is unset or is set to ``0``.
 
-Usage
+Python Usage
+------------
+
+    >>> from flask_taxonomies.managers import TaxonomyManager
+    >>> from flask_taxonomies.models import Taxonomy, TaxonomyTerm
+    >>> # To create Taxonomy:
+    >>> t = Taxonomy(code='taxcode')
+    >>> # To create TaxonomyTerm
+    >>> m = TaxonomyManager()
+    >>> term = m.create('slug', title={'en': 'Tax Term'}, path='/taxcode/taxterm', extra_data={})
+    >>> # To get taxonomy by code
+    >>> t = m.get_taxonomy('taxcode')
+    >>> # To list taxonomy top-level terms
+    >>> terms = list(m.get_taxonomy_roots(t))
+    >>> # To get term by taxonomy and slug
+    >>> term = m.get_term(t, 'taxcode')
+    >>> # To get term from taxonomy path
+    >>> t, term = manager.get_from_path('/taxcode/taxterm')
+    >>> # To move term to a different path
+    >>> m.move_tree('/taxcode/taxterm/', '/anothertax/otherterm/') # moves term subtree to '/anothertax/otherterm/taxterm/'
+    >>> # To delete term and its descendants
+    >>> m.delete_tree('/taxcode/taxterm/')
+    >>> # To update Taxonomy/TaxonomyTerm
+    >>> t.update(extra_data={'updated': true})
+    >>> # To delete Taxonomy (including all related terms) or a single TaxonomyTerm
+    >>> db.session.delete(t)
+
+REST API Usage
 -----
 
-Create taxonomies ::
+To list available taxonomies ::
+
+    curl -X GET http://localhost:5000/taxonomies/
+    > [{'code': ..., 'extra_data': ...}, ...]
+
+To create taxonomy ::
 
     curl -X POST \
-      http://localhost:5000/taxonomies/vehicle/ \
-      -d '{"title": "{\"en\": \"Vehicle\"}", "description": "Some Vehicle"}'
+      http://localhost:5000/taxonomies/ \
+      -d '{"code": "...", "extra_data": "{...}"}'
 
-    curl -X POST \
-      http://localhost:5000/taxonomies/vehicle/land-vehicle/ \
-      -d '{"title": "{\"en\": \"Land Vehicle\"}", "description": "Land Vehicle"}'
+To list top-level terms in a taxonomy ::
 
-    curl -X POST \
-      http://localhost:5000/taxonomies/car/ \
-      -d '{"title": "{\"en\": \"Vehicle\"}", "description": "Some Vehicle", "attach_to": "land-vehicle"}'
+    curl -X GET http://localhost:5000/taxonomies/<taxonomy-code>/
+    > [{'slug': ..., ...}, {'slug': ..., ...}, ...]
 
+To get Taxonomy Term details ::
 
-List taxonomies ::
+    curl -X GET http://localhost:5000/taxonomies/<taxonomy-code>/<taxonomy-term-path>/
+    > {'slug': ..., 'title': ..., 'extra_data', ..., 'children': [...], ...}
 
-    curl -X GET http://localhost:5000/taxonomies/car/
-    > [ { "description": "A Car", "id": 7, "label": "", "path": "vehicle/land-vehicle/car", "slug": "car", "title": "{\"en\": \"Car\"}" } ]
-
-    curl -X GET http://localhost:5000/taxonomies/vehicle/land-vehicle/
-    > [ { "children": [ { "description": "A Car", "id": 7, "label": "", "path": "vehicle/land-vehicle/car", "slug": "car", "title": "{\"en\": \"Car\"}" } ], "description": "Some Land Vehicle", "id": 6, "label": "", "path": "vehicle/land-vehicle", "slug": "land-vehicle", "title": "{\"en\": \"Land Vehicle\"}" } ]
-
-Update taxonomy entry ::
-
-    curl -X PATCH \
-      http://localhost:5000/taxonomies/vehicle/land-vehicle/ \
-      -d '{"description": "A Fancy Land vehicle"}'
-
-Delete taxonomy (or TaxonomyTerm subtree) ::
+Delete taxonomy (including all its terms) ::
 
     curl -X DELETE \
-      http://localhost:5000/taxonomies/vehicle/land-vehicle/
+      http://localhost:5000/taxonomies/<taxonomy-code>
+
+Delete taxonomy term (including all its childrens) ::
+
+    curl -X DELETE \
+      http://localhost:5000/taxonomies/<taxonomy-code>/<taxonomy-term-path>/
 
 Move taxonony (or whole subtree) to another tree (identified by slug) ::
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Flask Taxonomies
 .. image:: https://img.shields.io/coveralls/oarepo/flask-taxonomies.svg
         :target: https://coveralls.io/r/oarepo/flask-taxonomies
 
-Taxonomy trees REST API for Flask Applications
+TaxonomyTerm trees REST API for Flask Applications
 
 
 Quickstart
@@ -77,7 +77,7 @@ Update taxonomy entry ::
       http://localhost:5000/taxonomies/vehicle/land-vehicle/ \
       -d '{"description": "A Fancy Land vehicle"}'
 
-Delete taxonomy (or Taxonomy subtree) ::
+Delete taxonomy (or TaxonomyTerm subtree) ::
 
     curl -X DELETE \
       http://localhost:5000/taxonomies/vehicle/land-vehicle/

--- a/flask_taxonomies/managers.py
+++ b/flask_taxonomies/managers.py
@@ -16,11 +16,15 @@ class TaxonomyManager(object):
         """Create TaxonomyTerm on a given path."""
         taxonomy, parent_term = TaxonomyManager.get_from_path(path)
         if not taxonomy:
-            raise AttributeError('Invalid Taxonomy path.')
+            raise AttributeError("Invalid Taxonomy path.")
 
         for term in taxonomy.terms:
             if term.slug == slug:
-                raise ValueError('Slug {slug} already exists within {tax}.'.format(slug=slug, tax=taxonomy))
+                raise ValueError(
+                    "Slug {slug} already exists within {tax}.".format(
+                        slug=slug, tax=taxonomy
+                    )
+                )
 
         t = TaxonomyTerm(slug, title, taxonomy, extra_data)
 
@@ -37,7 +41,7 @@ class TaxonomyManager(object):
         """Delete a subtree of Terms on a given path."""
         taxo, term = TaxonomyManager.get_from_path(path)
         if not term:
-            raise AttributeError('Invalid TaxonomyTerm path.')
+            raise AttributeError("Invalid TaxonomyTerm path.")
 
         db.session.delete(term)
         db.session.commit()
@@ -47,16 +51,18 @@ class TaxonomyManager(object):
         """Get Taxonomy and Term on a given path in Taxonomy."""
         taxonomy = None
         term = None
-        parts = list(filter(None, path.lstrip('/').split('/', 1)))
+        parts = list(filter(None, path.lstrip("/").split("/", 1)))
 
         if len(parts) >= 1:
             taxonomy = TaxonomyManager.get_taxonomy(parts[0])
 
         if taxonomy and len(parts) == 2:
-            slug = parts[1].rstrip('/').split('/')[-1]
+            slug = parts[1].rstrip("/").split("/")[-1]
             term = TaxonomyManager.get_term(taxonomy=taxonomy, slug=slug)
             if not term:
-                raise AttributeError('TaxonomyTerm path {path} does not exist.'.format(path=parts))
+                raise AttributeError(
+                    "TaxonomyTerm path {path} does not exist.".format(path=parts)
+                )
 
         return (taxonomy, term)
 
@@ -73,29 +79,32 @@ class TaxonomyManager(object):
     @staticmethod
     def get_term(taxonomy: Taxonomy, slug: str) -> Optional[TaxonomyTerm]:
         """Get TaxonomyTerm by its slug or None if not found."""
-        return TaxonomyTerm.query.filter(and_(TaxonomyTerm.slug == slug, TaxonomyTerm.taxonomy == taxonomy)).first()
+        return TaxonomyTerm.query.filter(
+            and_(TaxonomyTerm.slug == slug, TaxonomyTerm.taxonomy == taxonomy)
+        ).first()
 
     @staticmethod
     def insert_term_under(term: TaxonomyTerm, under: TaxonomyTerm):
-        """Insert/Move Term under another term in tree structure"""
+        """Insert/Move Term under another term in tree structure."""
         term.move_inside(under.id)
 
     @staticmethod
     def move_tree(source_path: str, destination_path: str):
+        """Move Term to another location."""
         stax, sterm = TaxonomyManager.get_from_path(source_path)
         dtax, dterm = TaxonomyManager.get_from_path(destination_path)
 
         if not stax or not sterm:
-            raise AttributeError('Invalid source Taxonomy tree path.')
+            raise AttributeError("Invalid source Taxonomy tree path.")
         if not dtax:
-            raise AttributeError('Invalid destination Taxonomy tree path')
+            raise AttributeError("Invalid destination Taxonomy tree path")
 
         def _update_children(children: dict) -> TaxonomyTerm:
-            if 'children' in children:
-                for child in children['children']:
+            if "children" in children:
+                for child in children["children"]:
                     node = _update_children(child)
 
-            node = children['node']
+            node = children["node"]
             node.taxonomy = dtax
             # db.session.add(node)
             return node

--- a/flask_taxonomies/managers.py
+++ b/flask_taxonomies/managers.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Managers module for database models."""
+from sqlalchemy import and_
+
+from flask_taxonomies.extensions import db
+from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+
+
+class TaxonomyManager(object):
+    """Manager of Taxonomy tree db models."""
+
+    def create(self, slug: str, title: dict, path: str, extra_data=None) -> TaxonomyTerm:
+        """Create TaxonomyTerm on a given path."""
+        taxonomy, parent_term = self.get_from_path(path)
+        if not taxonomy:
+            raise AttributeError('Invalid Taxonomy path.')
+
+        for term in taxonomy.terms:
+            if term.slug == slug:
+                raise ValueError('Slug {slug} already exists within {tax}.'.format(slug=slug, tax=taxonomy))
+
+        t = TaxonomyTerm(slug, title, taxonomy, extra_data)
+
+        if parent_term:
+            self.insert_term_under(t, parent_term)
+
+        db.session.add(t)
+        db.session.commit()
+
+        return t
+
+    def delete_tree(self, path: str):
+        """Delete a subtree of Terms on a given path."""
+        taxo, term = self.get_from_path(path)
+        if not term:
+            raise AttributeError('Invalid TaxonomyTerm path.')
+
+        db.session.delete(term)
+        db.session.commit()
+
+    def delete_taxonomy(self, taxonomy: Taxonomy):
+        """Delete whole Taxonomy including all its terms."""
+
+    def get_from_path(self, path: str) -> (Taxonomy, TaxonomyTerm):
+        """Get Taxonomy and Term on a given path in Taxonomy."""
+        taxonomy = None
+        term = None
+        parts = list(filter(None, path.lstrip('/').split('/', 1)))
+
+        if len(parts) >= 1:
+            taxonomy = self.get_taxonomy(parts[0])
+
+        if taxonomy and len(parts) == 2:
+            slug = parts[1].rstrip('/').split('/')[-1]
+            term = self.get_term(taxonomy=taxonomy, slug=slug)
+            if not term:
+                raise AttributeError('TaxonomyTerm path {path} does not exist.'.format(path=parts))
+
+        return (taxonomy, term)
+
+    def get_taxonomy(self, code) -> Taxonomy:
+        """Return taxonomy identified by code."""
+        return Taxonomy.query.filter(Taxonomy.code == code).first()
+
+    def get_term(self, taxonomy: Taxonomy, slug: str) -> TaxonomyTerm:
+        """Get TaxonomyTerm by its slug."""
+        return TaxonomyTerm.query.filter(and_(TaxonomyTerm.slug == slug, TaxonomyTerm.taxonomy == taxonomy)).first()
+
+    def insert_term_under(self, term: TaxonomyTerm, under: TaxonomyTerm):
+        """Insert/Move Term under another term in tree structure"""
+        term.move_inside(under.id)
+
+    def move_tree(self, source_path: str, destination_path: str):
+        stax, sterm = self.get_from_path(source_path)
+        dtax, dterm = self.get_from_path(destination_path)
+
+        if not stax or not sterm:
+            raise AttributeError('Invalid source Taxonomy tree path.')
+        if not dtax:
+            raise AttributeError('Invalid destination Taxonomy tree path')
+
+        def _update_children(children: dict) -> TaxonomyTerm:
+            if 'children' in children:
+                for child in children['children']:
+                    node = _update_children(child)
+
+            node = children['node']
+            node.taxonomy = dtax
+            #db.session.add(node)
+            return node
+
+        children = sterm.drilldown_tree()[0]
+        _update_children(children)
+
+        sterm.move_inside(dterm)
+        db.session.add(sterm)
+        db.session.commit()

--- a/flask_taxonomies/managers.py
+++ b/flask_taxonomies/managers.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Managers module for database models."""
-from typing import Optional, Iterator
+from typing import Iterator, Optional
 
 from sqlalchemy import and_
 
 from flask_taxonomies.extensions import db
-from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
 
 class TaxonomyManager(object):

--- a/flask_taxonomies/managers.py
+++ b/flask_taxonomies/managers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Managers module for database models."""
+from typing import Optional, Iterator
+
 from sqlalchemy import and_
 
 from flask_taxonomies.extensions import db
@@ -9,9 +11,10 @@ from flask_taxonomies.models import TaxonomyTerm, Taxonomy
 class TaxonomyManager(object):
     """Manager of Taxonomy tree db models."""
 
-    def create(self, slug: str, title: dict, path: str, extra_data=None) -> TaxonomyTerm:
+    @staticmethod
+    def create(slug: str, title: dict, path: str, extra_data=None) -> TaxonomyTerm:
         """Create TaxonomyTerm on a given path."""
-        taxonomy, parent_term = self.get_from_path(path)
+        taxonomy, parent_term = TaxonomyManager.get_from_path(path)
         if not taxonomy:
             raise AttributeError('Invalid Taxonomy path.')
 
@@ -22,57 +25,65 @@ class TaxonomyManager(object):
         t = TaxonomyTerm(slug, title, taxonomy, extra_data)
 
         if parent_term:
-            self.insert_term_under(t, parent_term)
+            TaxonomyManager.insert_term_under(t, parent_term)
 
         db.session.add(t)
         db.session.commit()
 
         return t
 
-    def delete_tree(self, path: str):
+    @staticmethod
+    def delete_tree(path: str):
         """Delete a subtree of Terms on a given path."""
-        taxo, term = self.get_from_path(path)
+        taxo, term = TaxonomyManager.get_from_path(path)
         if not term:
             raise AttributeError('Invalid TaxonomyTerm path.')
 
         db.session.delete(term)
         db.session.commit()
 
-    def delete_taxonomy(self, taxonomy: Taxonomy):
-        """Delete whole Taxonomy including all its terms."""
-
-    def get_from_path(self, path: str) -> (Taxonomy, TaxonomyTerm):
+    @staticmethod
+    def get_from_path(path: str) -> (Taxonomy, TaxonomyTerm):
         """Get Taxonomy and Term on a given path in Taxonomy."""
         taxonomy = None
         term = None
         parts = list(filter(None, path.lstrip('/').split('/', 1)))
 
         if len(parts) >= 1:
-            taxonomy = self.get_taxonomy(parts[0])
+            taxonomy = TaxonomyManager.get_taxonomy(parts[0])
 
         if taxonomy and len(parts) == 2:
             slug = parts[1].rstrip('/').split('/')[-1]
-            term = self.get_term(taxonomy=taxonomy, slug=slug)
+            term = TaxonomyManager.get_term(taxonomy=taxonomy, slug=slug)
             if not term:
                 raise AttributeError('TaxonomyTerm path {path} does not exist.'.format(path=parts))
 
         return (taxonomy, term)
 
-    def get_taxonomy(self, code) -> Taxonomy:
-        """Return taxonomy identified by code."""
+    @staticmethod
+    def get_taxonomy(code) -> Optional[Taxonomy]:
+        """Return taxonomy identified by code or None if not found."""
         return Taxonomy.query.filter(Taxonomy.code == code).first()
 
-    def get_term(self, taxonomy: Taxonomy, slug: str) -> TaxonomyTerm:
-        """Get TaxonomyTerm by its slug."""
+    @staticmethod
+    def get_taxonomy_roots(taxonomy: Taxonomy) -> Iterator:
+        """Return a list of top-level TaxonomyTerms."""
+        return filter(lambda t: t.parent is None, taxonomy.terms)
+
+    @staticmethod
+    def get_term(taxonomy: Taxonomy, slug: str) -> Optional[TaxonomyTerm]:
+        """Get TaxonomyTerm by its slug or None if not found."""
         return TaxonomyTerm.query.filter(and_(TaxonomyTerm.slug == slug, TaxonomyTerm.taxonomy == taxonomy)).first()
 
-    def insert_term_under(self, term: TaxonomyTerm, under: TaxonomyTerm):
+    @staticmethod
+    def insert_term_under(term: TaxonomyTerm, under: TaxonomyTerm):
         """Insert/Move Term under another term in tree structure"""
         term.move_inside(under.id)
 
-    def move_tree(self, source_path: str, destination_path: str):
-        stax, sterm = self.get_from_path(source_path)
-        dtax, dterm = self.get_from_path(destination_path)
+    @staticmethod
+    def move_tree(source_path: str, destination_path: str):
+        stax, sterm = TaxonomyManager.get_from_path(source_path)
+        dtax, dterm = TaxonomyManager.get_from_path(destination_path)
 
         if not stax or not sterm:
             raise AttributeError('Invalid source Taxonomy tree path.')
@@ -86,12 +97,16 @@ class TaxonomyManager(object):
 
             node = children['node']
             node.taxonomy = dtax
-            #db.session.add(node)
+            # db.session.add(node)
             return node
 
         children = sterm.drilldown_tree()[0]
         _update_children(children)
 
-        sterm.move_inside(dterm)
+        if dterm:
+            sterm.move_inside(dterm.id)
+        else:
+            sterm.move_inside(dtax.id)
+
         db.session.add(sterm)
         db.session.commit()

--- a/flask_taxonomies/models.py
+++ b/flask_taxonomies/models.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """User models."""
+from sqlalchemy import asc
+from sqlalchemy.orm import relationship
 from sqlalchemy_mptt import BaseNestedSets
 
 from flask_taxonomies.compat import basestring
@@ -19,30 +21,63 @@ class SurrogatePK(object):
     def get_by_id(cls, record_id):
         """Get record by ID."""
         if any(
-            (
-                isinstance(record_id, basestring) and record_id.isdigit(),
-                isinstance(record_id, (int, float)),
-            )
+                (
+                        isinstance(record_id, basestring) and record_id.isdigit(),
+                        isinstance(record_id, (int, float)),
+                )
         ):
             return cls.query.get(int(record_id))
         return None
 
 
-class Taxonomy(SurrogatePK, db.Model, BaseNestedSets):
-    """Taxonomy adjacency list model."""
+class Taxonomy(SurrogatePK, db.Model):
+    __tablename__ = 'taxonomy'
+    code = db.Column(db.String(64), unique=True)
+    extra_data = db.Column(db.JSON)
+    terms = relationship('TaxonomyTerm', cascade='all,delete', back_populates='taxonomy')
 
-    __tablename__ = "taxonomy"
-    slug = db.Column(db.String(64), unique=True)
-    title = db.Column(db.JSON)
-    description = db.Column(db.String(256))
+    def __init__(self, code: str):
+        """Taxonomy constructor."""
+        self.code = code
+
+    def update(self, extra_data: dict = None):
+        self.extra_data = extra_data
+        db.session.add(self)
+        db.session.commit()
 
     def __repr__(self):
         """Represent taxonomy instance as a unique string."""
-        return "<Taxonomy({slug})>".format(slug=self.slug)
+        return "<Taxonomy({code})>".format(code=self.code)
 
-    @classmethod
-    def get_by_slug(cls, slug):
-        """Get Taxonomy unique slug."""
-        if isinstance(slug, str):
-            return cls.query.filter(cls.slug == slug).first()
-        return None
+
+class TaxonomyTerm(SurrogatePK, db.Model, BaseNestedSets):
+    """TaxonomyTerm adjacency list model."""
+
+    __tablename__ = 'taxonomy_term'
+    slug = db.Column(db.String(64), unique=False)
+    title = db.Column(db.JSON)
+    extra_data = db.Column(db.JSON)
+    taxonomy_id = db.Column(db.Integer, db.ForeignKey('taxonomy.id'))
+    taxonomy = relationship('Taxonomy', back_populates='terms')
+
+    def __repr__(self):
+        """Represent taxonomy term instance as a unique string."""
+        return "<TaxonomyTerm({slug}:{path})>".format(slug=self.slug, path=self.id)
+
+    def __init__(self, slug: str, title: dict, taxonomy: Taxonomy, extra_data: dict = None):
+        """TaxonomyTerm constructor."""
+        self.slug = slug
+        self.title = title
+        self.taxonomy = taxonomy
+        self.extra_data = extra_data
+
+    def update(self, title: dict = None, extra_data: dict = None):
+        self.title = title
+        self.extra_data = extra_data
+        db.session.add(self)
+        db.session.commit()
+
+    @property
+    def tree_path(self) -> str:
+        return "/{code}/{path}".format(code=self.taxonomy.code,
+                                       path='/'.join([t.slug for t in self.path_to_root(order=asc).all()]))

--- a/flask_taxonomies/models.py
+++ b/flask_taxonomies/models.py
@@ -21,20 +21,24 @@ class SurrogatePK(object):
     def get_by_id(cls, record_id):
         """Get record by ID."""
         if any(
-                (
-                        isinstance(record_id, basestring) and record_id.isdigit(),
-                        isinstance(record_id, (int, float)),
-                )
+            (
+                isinstance(record_id, basestring) and record_id.isdigit(),
+                isinstance(record_id, (int, float)),
+            )
         ):
             return cls.query.get(int(record_id))
         return None
 
 
 class Taxonomy(SurrogatePK, db.Model):
-    __tablename__ = 'taxonomy'
+    """Taxonomy model."""
+
+    __tablename__ = "taxonomy"
     code = db.Column(db.String(64), unique=True)
     extra_data = db.Column(db.JSON)
-    terms = relationship('TaxonomyTerm', cascade='all,delete', back_populates='taxonomy')
+    terms = relationship(
+        "TaxonomyTerm", cascade="all,delete", back_populates="taxonomy"
+    )
 
     def __init__(self, code: str, extra_data: dict = None):
         """Taxonomy constructor."""
@@ -42,6 +46,7 @@ class Taxonomy(SurrogatePK, db.Model):
         self.extra_data = extra_data
 
     def update(self, extra_data: dict = None):
+        """Update taxonomy extra_data."""
         self.extra_data = extra_data
         db.session.add(self)
         db.session.commit()
@@ -54,25 +59,28 @@ class Taxonomy(SurrogatePK, db.Model):
 class TaxonomyTerm(SurrogatePK, db.Model, BaseNestedSets):
     """TaxonomyTerm adjacency list model."""
 
-    __tablename__ = 'taxonomy_term'
+    __tablename__ = "taxonomy_term"
     slug = db.Column(db.String(64), unique=False)
     title = db.Column(db.JSON)
     extra_data = db.Column(db.JSON)
-    taxonomy_id = db.Column(db.Integer, db.ForeignKey('taxonomy.id'))
-    taxonomy = relationship('Taxonomy', back_populates='terms')
+    taxonomy_id = db.Column(db.Integer, db.ForeignKey("taxonomy.id"))
+    taxonomy = relationship("Taxonomy", back_populates="terms")
 
     def __repr__(self):
         """Represent taxonomy term instance as a unique string."""
         return "<TaxonomyTerm({slug}:{path})>".format(slug=self.slug, path=self.id)
 
-    def __init__(self, slug: str, title: dict, taxonomy: Taxonomy, extra_data: dict = None):
-        """TaxonomyTerm constructor."""
+    def __init__(
+        self, slug: str, title: dict, taxonomy: Taxonomy, extra_data: dict = None
+    ):
+        """Taxonomy Term constructor."""
         self.slug = slug
         self.title = title
         self.taxonomy = taxonomy
         self.extra_data = extra_data
 
     def update(self, title: dict = None, extra_data: dict = None):
+        """Update Taxonomy Term data."""
         self.title = title
         self.extra_data = extra_data
         db.session.add(self)
@@ -80,5 +88,8 @@ class TaxonomyTerm(SurrogatePK, db.Model, BaseNestedSets):
 
     @property
     def tree_path(self) -> str:
-        return "/{code}/{path}".format(code=self.taxonomy.code,
-                                       path='/'.join([t.slug for t in self.path_to_root(order=asc).all()]))
+        """Get path in a taxonomy tree."""
+        return "/{code}/{path}".format(
+            code=self.taxonomy.code,
+            path="/".join([t.slug for t in self.path_to_root(order=asc).all()]),
+        )

--- a/flask_taxonomies/models.py
+++ b/flask_taxonomies/models.py
@@ -36,9 +36,10 @@ class Taxonomy(SurrogatePK, db.Model):
     extra_data = db.Column(db.JSON)
     terms = relationship('TaxonomyTerm', cascade='all,delete', back_populates='taxonomy')
 
-    def __init__(self, code: str):
+    def __init__(self, code: str, extra_data: dict = None):
         """Taxonomy constructor."""
         self.code = code
+        self.extra_data = extra_data
 
     def update(self, extra_data: dict = None):
         self.extra_data = extra_data

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -71,7 +71,16 @@ def target_path_validator(value: str):
 
 def jsonify_taxonomy(t: Taxonomy) -> dict:
     """Prepare Taxonomy to be easily jsonified."""
-    return {"id": t.id, "code": t.code, "extra_data": t.extra_data}
+    return {
+        "id": t.id,
+        "code": t.code,
+        "extra_data": t.extra_data,
+        "links": {
+            "self": url_for(
+                "taxonomies.taxonomy_get_roots", taxonomy_code=t.code, _external=True
+            )
+        },
+    }
 
 
 def jsonify_taxonomy_term(t: TaxonomyTerm, drilldown: bool = False) -> dict:

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -13,7 +13,7 @@ from flask_taxonomies.extensions import db
 from flask_taxonomies.managers import TaxonomyManager
 from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
-blueprint = Blueprint('taxonomies', __name__, url_prefix='/taxonomies')
+blueprint = Blueprint("taxonomies", __name__, url_prefix="/taxonomies")
 
 
 def pass_taxonomy(f):
@@ -21,10 +21,10 @@ def pass_taxonomy(f):
 
     @wraps(f)
     def decorate(*args, **kwargs):
-        code = kwargs.pop('taxonomy_code')
+        code = kwargs.pop("taxonomy_code")
         taxonomy = TaxonomyManager.get_taxonomy(code=code)
         if not taxonomy:
-            abort(404, 'Taxonomy does not exist.')
+            abort(404, "Taxonomy does not exist.")
         return f(taxonomy=taxonomy, *args, **kwargs)
 
     return decorate
@@ -35,15 +35,15 @@ def pass_term(f):
 
     @wraps(f)
     def decorate(*args, **kwargs):
-        code = kwargs.pop('taxonomy_code')
-        path = kwargs.pop('term_path')
+        code = kwargs.pop("taxonomy_code")
+        path = kwargs.pop("term_path")
         try:
-            _, term = TaxonomyManager.get_from_path('/{}/{}'.format(code, path))
+            _, term = TaxonomyManager.get_from_path("/{}/{}".format(code, path))
         except AttributeError:
             term = None
 
         if not term:
-            abort(404, 'Taxonomy Term does not exist on a specified path.')
+            abort(404, "Taxonomy Term does not exist on a specified path.")
         return f(term=term, *args, **kwargs)
 
     return decorate
@@ -54,7 +54,7 @@ def json_validator(value: str):
     try:
         json.loads(value)
     except JSONDecodeError as e:
-        return abort(400, 'Invalid JSON: {}'.format(e))
+        return abort(400, "Invalid JSON: {}".format(e))
 
 
 def target_path_validator(value: str):
@@ -63,62 +63,67 @@ def target_path_validator(value: str):
     try:
         tax, term = TaxonomyManager.get_from_path(value)
     except AttributeError:
-        abort(400, 'Target Path is invalid.')
+        abort(400, "Target Path is invalid.")
 
     if not tax:
-        abort(400, 'Invalid Taxonomy in Target Path')
+        abort(400, "Invalid Taxonomy in Target Path")
 
 
 def jsonify_taxonomy(t: Taxonomy) -> dict:
     """Prepare Taxonomy to be easily jsonified."""
-    return {
-        'id': t.id,
-        'code': t.code,
-        'extra_data': t.extra_data,
-    }
+    return {"id": t.id, "code": t.code, "extra_data": t.extra_data}
 
 
 def jsonify_taxonomy_term(t: TaxonomyTerm, drilldown: bool = False) -> dict:
     """Prepare TaxonomyTerm to be easily jsonified."""
     result = {
-        'id': t.id,
-        'slug': t.slug,
-        'title': t.title,
-        'extra_data': t.extra_data,
-        'path': t.tree_path,
-        'links': {
+        "id": t.id,
+        "slug": t.slug,
+        "title": t.title,
+        "extra_data": t.extra_data,
+        "path": t.tree_path,
+        "links": {
             # TODO: replace with Term detail route
-            'self': url_for('taxonomies.taxonomy_get_term',
-                            taxonomy_code=t.taxonomy.code,
-                            term_path=(''.join(t.tree_path.split('/', 2)[2:])),
-                            _external=True)
-        }
+            "self": url_for(
+                "taxonomies.taxonomy_get_term",
+                taxonomy_code=t.taxonomy.code,
+                term_path=("".join(t.tree_path.split("/", 2)[2:])),
+                _external=True,
+            )
+        },
     }
     if drilldown:
+
         def _term_fields(term: TaxonomyTerm):
             return dict(slug=term.slug, path=term.tree_path)
 
-        result.update({'children': t.drilldown_tree(json=True, json_fields=_term_fields)})
+        result.update(
+            {"children": t.drilldown_tree(json=True, json_fields=_term_fields)}
+        )
 
     return result
 
 
-@blueprint.route('/', methods=('GET',))
+@blueprint.route("/", methods=("GET",))
 def taxonomy_list():
+    """List all available taxonomies."""
     taxonomies = Taxonomy.query.all()
     return jsonify([jsonify_taxonomy(t) for t in taxonomies])
 
 
-@blueprint.route('/', methods=('POST',))
+@blueprint.route("/", methods=("POST",))
 @use_kwargs(
     {
-        'code': fields.Str(required=True),
-        'extra_data': fields.Str(required=False, empty_value='', validate=json_validator),
+        "code": fields.Str(required=True),
+        "extra_data": fields.Str(
+            required=False, empty_value="", validate=json_validator
+        ),
     }
 )
 def taxonomy_create(code: str, extra_data: dict = None):
+    """Create a new Taxonomy."""
     if TaxonomyManager.get_taxonomy(code):
-        raise BadRequest('Taxonomy with this code already exists.')
+        raise BadRequest("Taxonomy with this code already exists.")
     else:
         t = Taxonomy(code=code, extra_data=json.loads(extra_data))
         db.session.add(t)
@@ -131,6 +136,7 @@ def taxonomy_create(code: str, extra_data: dict = None):
 @blueprint.route("/<string:taxonomy_code>/", methods=("GET",))
 @pass_taxonomy
 def taxonomy_get_roots(taxonomy):
+    """Get top-level terms in a Taxonomy."""
     roots = TaxonomyManager.get_taxonomy_roots(taxonomy)
     return jsonify([jsonify_taxonomy_term(t) for t in roots])
 
@@ -138,45 +144,54 @@ def taxonomy_get_roots(taxonomy):
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("GET",))
 @pass_term
 def taxonomy_get_term(term):
+    """Get Taxonomy Term detail."""
     return jsonify(jsonify_taxonomy_term(term, drilldown=True))
 
 
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("POST",))
 @use_kwargs(
     {
-        'title': fields.Str(required=True, validate=json_validator),
-        'extra_data': fields.Str(required=False, empty_value='', validate=json_validator),
+        "title": fields.Str(required=True, validate=json_validator),
+        "extra_data": fields.Str(
+            required=False, empty_value="", validate=json_validator
+        ),
     }
 )
 def taxonomy_create_term(taxonomy_code, term_path, title, extra_data=None):
+    """Create a Term inside a Taxonomy tree."""
     taxonomy = None
     term = None
     try:
-        taxonomy, term = TaxonomyManager.get_from_path('/{}/{}'.format(taxonomy_code, term_path))
+        taxonomy, term = TaxonomyManager.get_from_path(
+            "/{}/{}".format(taxonomy_code, term_path)
+        )
     except AttributeError:
         taxonomy = TaxonomyManager.get_taxonomy(taxonomy_code)
 
     if not taxonomy:
-        abort(404, 'Taxonomy does not exist, create it first.')
+        abort(404, "Taxonomy does not exist, create it first.")
     if term:
-        abort(400, 'Term already exists on a path specified.')
+        abort(400, "Term already exists on a path specified.")
 
-    path, slug = '/{}'.format(term_path).rstrip('/').rsplit('/', 1)
-    full_path = '/{}{}'.format(taxonomy.code, path)
+    path, slug = "/{}".format(term_path).rstrip("/").rsplit("/", 1)
+    full_path = "/{}{}".format(taxonomy.code, path)
 
     try:
         title = json.loads(title)
-        created = TaxonomyManager.create(slug=slug, title=title, extra_data=extra_data, path='{}'.format(full_path))
+        created = TaxonomyManager.create(
+            slug=slug, title=title, extra_data=extra_data, path="{}".format(full_path)
+        )
         response = jsonify(jsonify_taxonomy_term(created, drilldown=True))
         response.status_code = 201
         return response
     except AttributeError:
-        abort(400, 'Invalid Taxonomy Term path provided.')
+        abort(400, "Invalid Taxonomy Term path provided.")
 
 
 @blueprint.route("/<string:taxonomy_code>/", methods=("DELETE",))
 @pass_taxonomy
 def taxonomy_delete(taxonomy):
+    """Delete whole taxonomy tree."""
     db.session.delete(taxonomy)
     db.session.commit()
     response = jsonify()
@@ -188,6 +203,7 @@ def taxonomy_delete(taxonomy):
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("DELETE",))
 @pass_term
 def taxonomy_delete_term(term):
+    """Delete a Term subtree in a Taxonomy."""
     TaxonomyManager.delete_tree(term.tree_path)
     response = jsonify()
     response.status_code = 204
@@ -197,12 +213,11 @@ def taxonomy_delete_term(term):
 
 @blueprint.route("/<string:taxonomy_code>/", methods=("PATCH",))
 @use_kwargs(
-    {
-        'extra_data': fields.Str(required=True, empty_value=None, validate=json_validator),
-    }
+    {"extra_data": fields.Str(required=True, empty_value=None, validate=json_validator)}
 )
 @pass_taxonomy
 def taxonomy_update(taxonomy, extra_data):
+    """Update Taxonomy."""
     taxonomy.update(json.loads(extra_data))
 
     return jsonify(jsonify_taxonomy(taxonomy))
@@ -211,18 +226,23 @@ def taxonomy_update(taxonomy, extra_data):
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("PATCH",))
 @use_kwargs(
     {
-        'title': fields.Str(required=False, empty_value=None, validate=json_validator),
-        'extra_data': fields.Str(required=False, empty_value=None, validate=json_validator),
-        'move_target': fields.Str(required=False, empty_value=None, validate=target_path_validator)
+        "title": fields.Str(required=False, empty_value=None, validate=json_validator),
+        "extra_data": fields.Str(
+            required=False, empty_value=None, validate=json_validator
+        ),
+        "move_target": fields.Str(
+            required=False, empty_value=None, validate=target_path_validator
+        ),
     }
 )
 @pass_term
 def taxonomy_update_term(term, title=None, extra_data=None, move_target=None):
+    """Update Term in Taxonomy."""
     changes = {}
     if title:
-        changes.update({'title': json.loads(title)})
+        changes.update({"title": json.loads(title)})
     if extra_data:
-        changes.update({'extra_data': json.loads(extra_data)})
+        changes.update({"extra_data": json.loads(extra_data)})
 
     term.update(**changes)
 

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -1,165 +1,228 @@
 # -*- coding: utf-8 -*-
 """TaxonomyTerm views."""
-from flask import Blueprint, abort, jsonify
-from sqlalchemy import asc
+import json
+from functools import wraps
+from json import JSONDecodeError
+
+from flask import Blueprint, abort, jsonify, url_for
 from webargs import fields
 from webargs.flaskparser import use_kwargs
+from werkzeug.exceptions import BadRequest
 
 from flask_taxonomies.extensions import db
-from flask_taxonomies.models import TaxonomyTerm
+from flask_taxonomies.managers import TaxonomyManager
+from flask_taxonomies.models import TaxonomyTerm, Taxonomy
 
-blueprint = Blueprint("taxonomies", __name__, url_prefix="/taxonomies")
+blueprint = Blueprint('taxonomies', __name__, url_prefix='/taxonomies')
+
+
+def pass_taxonomy(f):
+    """Decorate to retrieve a bucket."""
+
+    @wraps(f)
+    def decorate(*args, **kwargs):
+        code = kwargs.pop('taxonomy_code')
+        taxonomy = TaxonomyManager.get_taxonomy(code=code)
+        if not taxonomy:
+            abort(404, 'Taxonomy does not exist.')
+        return f(taxonomy=taxonomy, *args, **kwargs)
+
+    return decorate
+
+
+def pass_term(f):
+    """Decorate to retrieve a bucket."""
+
+    @wraps(f)
+    def decorate(*args, **kwargs):
+        code = kwargs.pop('taxonomy_code')
+        path = kwargs.pop('term_path')
+        try:
+            _, term = TaxonomyManager.get_from_path('/{}/{}'.format(code, path))
+        except AttributeError:
+            term = None
+
+        if not term:
+            abort(404, 'Taxonomy Term does not exist on a specified path.')
+        return f(term=term, *args, **kwargs)
+
+    return decorate
+
+
+def json_validator(value: str):
+    try:
+        json.loads(value)
+    except JSONDecodeError as e:
+        return abort(400, 'Invalid JSON: {}'.format(e))
 
 
 def slug_validator(value: str):
     """Validate if slug exists."""
     tax = TaxonomyTerm.get_by_slug(value)
     if not tax:
-        abort(400, "Invalid slug passed: {}".format(value))
+        abort(400, 'Invalid slug passed: {}'.format(value))
 
 
-def slug_path_validator(value: str):
-    """Validate if slug path exists in a tree."""
-    slugs = value.split("/")
-    for i, slug in enumerate(slugs):
-        slug_validator(slug)
-        if i > 0:
-            parent = TaxonomyTerm.get_by_slug(slugs[i - 1])
-            current: TaxonomyTerm = TaxonomyTerm.get_by_slug(slug)
-            if not current.parent_id == parent.id:
-                abort(400, "Invalid slug path passed: {}".format(value))
-
-
-def slug_path_parent(value: str) -> TaxonomyTerm:
-    """Get TaxonomyTerm instance for last component of slug path."""
-    return TaxonomyTerm.get_by_slug(value.split("/")[-1])
-
-
-def jsonify_taxonomy(t: TaxonomyTerm) -> dict:
-    """Prepare TaxonomyTerm to be easily jsonified."""
+def jsonify_taxonomy(t: Taxonomy) -> dict:
+    """Prepare Taxonomy to be easily jsonified."""
     return {
-        "id": t.id,
-        "label": str(t),
-        "slug": t.slug,
-        "title": t.title,
-        "description": t.extra_data,
-        "path": "/".join([tx.slug for tx in t.path_to_root(order=asc).all()]),
+        'id': t.id,
+        'code': t.code,
+        'extra_data': t.extra_data,
     }
 
 
-@blueprint.route("/", methods=("GET",))
-@blueprint.route("/<string:taxonomy_slug>/", methods=("GET",))
-@blueprint.route("/<path:taxonomy_path>/<string:taxonomy_slug>/", methods=("GET",))
-def taxonomy_list(taxonomy_id=None, taxonomy_path=None, taxonomy_slug=None):
-    """List all available taxonomy trees with a given optional parent slug."""
-    tax = None
-    result = None
+def jsonify_taxonomy_term(t: TaxonomyTerm, drilldown: bool = False) -> dict:
+    """Prepare TaxonomyTerm to be easily jsonified."""
+    result = {
+        'id': t.id,
+        'slug': t.slug,
+        'title': t.title,
+        'extra_data': t.extra_data,
+        'path': t.tree_path,
+        'links': {
+            # TODO: replace with Term detail route
+            'self': url_for('taxonomies.taxonomy_get_term',
+                            taxonomy_code=t.taxonomy.code,
+                            term_path=(''.join(t.tree_path.split('/', 2)[2:])),
+                            _external=True)
+        }
+    }
+    if drilldown:
+        def _term_fields(term: TaxonomyTerm):
+            return dict(slug=term.slug, path=term.tree_path)
 
-    if taxonomy_slug:
-        tax = TaxonomyTerm.get_by_slug(taxonomy_slug)
-        if not tax:
-            abort(404, "TaxonomyTerm not found.")
-        result = []
-        tax_tree = tax.drilldown_tree(json=True, json_fields=jsonify_taxonomy)
-        return jsonify(tax_tree)
-    else:
-        result = TaxonomyTerm.query.filter(TaxonomyTerm.parent_id == None).all()  # noqa E711
+        result.update({'children': t.drilldown_tree(json=True, json_fields=_term_fields)})
 
-    return jsonify([jsonify_taxonomy(t) for t in result])
+    return result
 
 
-@blueprint.route("/<string:slug>/", methods=("POST",))
-@blueprint.route("/<path:attach_to_path>/<string:slug>/", methods=("POST",))
+@blueprint.route('/', methods=('GET',))
+def taxonomy_list():
+    taxonomies = Taxonomy.query.all()
+    return jsonify([jsonify_taxonomy(t) for t in taxonomies])
+
+
+@blueprint.route('/', methods=('POST',))
 @use_kwargs(
     {
-        "title": fields.Str(required=True),
-        "description": fields.Str(required=False, empty=""),
-        "attach_to": fields.Str(required=False, validate=slug_validator),
+        'code': fields.Str(required=True),
+        'extra_data': fields.Str(required=False, empty_value='', validate=json_validator),
     }
 )
-def taxonomy_create(slug, title, description="", attach_to=None, attach_to_path=None):
-    """Create new TaxonomyTerm entry on a specified path, or attach it to a tree."""
-    if slug == "move":
-        abort(400, "Move is a reserved keyword")
-
-    if TaxonomyTerm.get_by_slug(slug):
-        abort(400, "TaxonomyTerm with this slug already exists.")
-
-    taxonomy = TaxonomyTerm(slug=slug, description=description, title=title)
-
-    if attach_to and attach_to_path:
-        abort(400, "You cannot use `attach_to` and `slug path` at the same time.")
-
-    if attach_to:
-        taxonomy.parent_id = slug_path_parent(attach_to).id
-    elif attach_to_path:
-        slug_path_validator(attach_to_path)
-        taxonomy.parent_id = slug_path_parent(attach_to_path).id
-
-    db.session.add(taxonomy)
-    db.session.commit()
-
-    response = jsonify(jsonify_taxonomy(taxonomy))
-    response.status_code = 201
-    return response
+def taxonomy_create(code: str, extra_data: dict = None):
+    if TaxonomyManager.get_taxonomy(code):
+        raise BadRequest('Taxonomy with this code already exists.')
+    else:
+        t = Taxonomy(code=code, extra_data=json.loads(extra_data))
+        db.session.add(t)
+        db.session.commit()
+        response = jsonify(jsonify_taxonomy(t))
+        response.status_code = 201
+        return response
 
 
-@blueprint.route("/<string:slug>/", methods=("DELETE",))
-@blueprint.route("/<path:taxonomy_path>/<string:slug>/", methods=("DELETE",))
-def taxonomy_delete(slug, taxonomy_path=None):
-    """Delete a TaxonomyTerm entry on a given path."""
-    slug_validator(slug)
-    if taxonomy_path:
-        slug_path_validator(taxonomy_path)
+@blueprint.route("/<string:taxonomy_code>/", methods=("GET",))
+@pass_taxonomy
+def taxonomy_get_roots(taxonomy):
+    roots = TaxonomyManager.get_taxonomy_roots(taxonomy)
+    return jsonify([jsonify_taxonomy_term(t) for t in roots])
 
-    taxonomy = TaxonomyTerm.get_by_slug(slug)
+
+@blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("GET",))
+@pass_term
+def taxonomy_get_term(term):
+    return jsonify(jsonify_taxonomy_term(term, drilldown=True))
+
+@blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("POST",))
+@use_kwargs(
+    {
+        'title': fields.Str(required=True, validate=json_validator),
+        'extra_data': fields.Str(required=False, empty_value='', validate=json_validator),
+    }
+)
+def taxonomy_create_term(taxonomy_code, term_path, title, extra_data = None):
+    taxonomy = None
+    term = None
+    try:
+        taxonomy, term = TaxonomyManager.get_from_path('/{}/{}'.format(taxonomy_code, term_path))
+    except AttributeError:
+        taxonomy = TaxonomyManager.get_taxonomy(taxonomy_code)
+
+    if not taxonomy:
+        abort(404, 'Taxonomy does not exist, create it first.')
+    if term:
+        abort(400, 'Term already exists on a path specified.')
+
+    path, slug = '/{}'.format(term_path).rstrip('/').rsplit('/', 1)
+    full_path = '/{}{}'.format(taxonomy.code, path)
+
+    try:
+        title = json.loads(title)
+        created = TaxonomyManager.create(slug=slug, title=title, extra_data=extra_data, path='{}'.format(full_path))
+        response = jsonify(jsonify_taxonomy_term(created, drilldown=True))
+        response.status_code = 201
+        return response
+    except AttributeError:
+        abort(400, 'Invalid Taxonomy Term path provided.')
+
+@blueprint.route("/<string:taxonomy_code>/", methods=("DELETE",))
+@pass_taxonomy
+def taxonomy_delete(taxonomy):
     db.session.delete(taxonomy)
     db.session.commit()
-
     response = jsonify()
     response.status_code = 204
     response.headers = []
     return response
 
-
-@blueprint.route("/<string:slug>/", methods=("PATCH",))
-@blueprint.route("/<path:taxonomy_path>/<string:slug>/", methods=("PATCH",))
-@use_kwargs(
-    {"title": fields.Str(required=False), "description": fields.Str(required=False)}
-)
-def taxonomy_patch(slug, title=False, description=False, taxonomy_path=None):
-    """Update TaxonomyTerm entry on a given path."""
-    slug_validator(slug)
-    if taxonomy_path:
-        slug_path_validator(taxonomy_path)
-
-    taxonomy = TaxonomyTerm.get_by_slug(slug)
-    if title:
-        taxonomy.title = title
-    if description:
-        taxonomy.description = description
-
-    db.session.add(taxonomy)
-    db.session.commit()
-
-    return jsonify(jsonify_taxonomy(taxonomy))
-
-
-@blueprint.route("/<string:slug>/move", methods=("POST",))
-@blueprint.route("/<path:taxonomy_path>/<string:slug>/move", methods=("POST",))
-@use_kwargs({"destination": fields.Str(required=True, validate=slug_validator)})
-def taxonomy_move(slug, destination, taxonomy_path=None):
-    """Move TaxonomyTerm tree to another tree."""
-    slug_validator(slug)
-    if taxonomy_path:
-        slug_path_validator(taxonomy_path)
-
-    source: TaxonomyTerm = TaxonomyTerm.get_by_slug(slug)
-    dest: TaxonomyTerm = TaxonomyTerm.get_by_slug(destination)
-
-    source.move_inside(dest.id)
-
-    db.session.add(source)
-    db.session.commit()
-
-    return jsonify(jsonify_taxonomy(source))
+@blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("DELETE",))
+@pass_term
+def taxonomy_delete_term(term):
+    TaxonomyManager.delete_tree(term.tree_path)
+    response = jsonify()
+    response.status_code = 204
+    response.headers = []
+    return response
+#
+# @blueprint.route("/<string:slug>/", methods=("PATCH",))
+# @blueprint.route("/<path:taxonomy_path>/<string:slug>/", methods=("PATCH",))
+# @use_kwargs(
+#     {"title": fields.Str(required=False), "description": fields.Str(required=False)}
+# )
+# def taxonomy_patch(slug, title=False, description=False, taxonomy_path=None):
+#     """Update TaxonomyTerm entry on a given path."""
+#     slug_validator(slug)
+#     if taxonomy_path:
+#         slug_path_validator(taxonomy_path)
+#
+#     taxonomy = TaxonomyTerm.get_by_slug(slug)
+#     if title:
+#         taxonomy.title = title
+#     if description:
+#         taxonomy.description = description
+#
+#     db.session.add(taxonomy)
+#     db.session.commit()
+#
+#     return jsonify(jsonify_taxonomy(taxonomy))
+#
+#
+# @blueprint.route("/<string:slug>/move", methods=("POST",))
+# @blueprint.route("/<path:taxonomy_path>/<string:slug>/move", methods=("POST",))
+# @use_kwargs({"destination": fields.Str(required=True, validate=slug_validator)})
+# def taxonomy_move(slug, destination, taxonomy_path=None):
+#     """Move TaxonomyTerm tree to another tree."""
+#     slug_validator(slug)
+#     if taxonomy_path:
+#         slug_path_validator(taxonomy_path)
+#
+#     source: TaxonomyTerm = TaxonomyTerm.get_by_slug(slug)
+#     dest: TaxonomyTerm = TaxonomyTerm.get_by_slug(destination)
+#
+#     source.move_inside(dest.id)
+#
+#     db.session.add(source)
+#     db.session.commit()
+#
+#     return jsonify(jsonify_taxonomy(source))

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,7 @@ pytest==4.6.3
 factory-boy==2.12.0
 pdbpp==0.10.0
 WebTest==2.0.30
+pydocstyle<4.0.0
 
 # Lint and code style
 black==19.3b0

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     license="MIT",
     author="Miroslav Bauer",
     author_email="bauer@cesnet.cz",
-    description="Taxonomy trees REST API for Flask Applications",
+    description="TaxonomyTerm trees REST API for Flask Applications",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def app():
 
 @pytest.fixture
 def manager(app):
+    """Taxonomy Manager fixture."""
     return TaxonomyManager
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ from webtest import TestApp
 
 from flask_taxonomies.app import create_app
 from flask_taxonomies.extensions import db as _db
-from flask_taxonomies.models import Taxonomy
+from flask_taxonomies.managers import TaxonomyManager
+from flask_taxonomies.models import TaxonomyTerm, Taxonomy
 
 
 @pytest.fixture
@@ -19,6 +20,11 @@ def app():
     yield _app
 
     ctx.pop()
+
+
+@pytest.fixture
+def manager(app):
+    return TaxonomyManager()
 
 
 @pytest.fixture
@@ -44,9 +50,7 @@ def db(app):
 @pytest.fixture
 def root_taxonomy(db):
     """Create root taxonomy element."""
-    root = Taxonomy(
-        slug="root", title='{"en": "Root"}', description="Taxonomy root term"
-    )
+    root = Taxonomy(code="root")
     db.session.add(root)
     db.session.commit()
     return root

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from webtest import TestApp
 from flask_taxonomies.app import create_app
 from flask_taxonomies.extensions import db as _db
 from flask_taxonomies.managers import TaxonomyManager
-from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+from flask_taxonomies.models import Taxonomy
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def app():
 
 @pytest.fixture
 def manager(app):
-    return TaxonomyManager()
+    return TaxonomyManager
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,15 +1,2 @@
 # -*- coding: utf-8 -*-
 """Factories to help in tests."""
-from factory.alchemy import SQLAlchemyModelFactory
-
-from flask_taxonomies.database import db
-
-
-class BaseFactory(SQLAlchemyModelFactory):
-    """Base factory."""
-
-    class Meta:
-        """Factory configuration."""
-
-        abstract = True
-        sqlalchemy_session = db.session

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,5 +9,3 @@ BCRYPT_LOG_ROUNDS = (
 DEBUG_TB_ENABLED = False
 CACHE_TYPE = "simple"  # Can be "memcached", "redis", etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = False
-WEBPACK_MANIFEST_PATH = "webpack/manifest.json"
-WTF_CSRF_ENABLED = False  # Allows form testing

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -3,6 +3,7 @@
 #
 # See: http://webtest.readthedocs.org/
 # """
+"""Functional unit tests using WebTest."""
 import json
 
 import pytest
@@ -16,205 +17,252 @@ class TestTaxonomyAPI:
 
     def test_list_taxonomies(self, db, testapp, root_taxonomy):
         """Test listing of taxonomies."""
-        additional = Taxonomy(code='additional', extra_data={'extra': 'data'})
+        additional = Taxonomy(code="additional", extra_data={"extra": "data"})
         db.session.add(additional)
         db.session.commit()
 
-        res = testapp.get('/taxonomies/')
+        res = testapp.get("/taxonomies/")
         jsonres = json.loads(res.body)
-        assert {'id': root_taxonomy.id, 'code': root_taxonomy.code, 'extra_data': root_taxonomy.extra_data} in jsonres
-        assert {'id': additional.id, 'code': additional.code, 'extra_data': additional.extra_data} in jsonres
+        assert {
+            "id": root_taxonomy.id,
+            "code": root_taxonomy.code,
+            "extra_data": root_taxonomy.extra_data,
+        } in jsonres
+        assert {
+            "id": additional.id,
+            "code": additional.code,
+            "extra_data": additional.extra_data,
+        } in jsonres
 
     def test_create_taxonomy(self, testapp, root_taxonomy):
         """Test Taxonomy creation."""
 
-        res = testapp.post('/taxonomies/', {'code': 'new', 'extra_data': '{"extra": "new"}'})
+        res = testapp.post(
+            "/taxonomies/", {"code": "new", "extra_data": '{"extra": "new"}'}
+        )
 
-        retrieved = Taxonomy.query.filter(Taxonomy.code == 'new').first()
+        retrieved = Taxonomy.query.filter(Taxonomy.code == "new").first()
         assert res.status_code == 201
         assert retrieved is not None
-        assert retrieved.extra_data == {'extra': 'new'}
+        assert retrieved.extra_data == {"extra": "new"}
 
         # Test putting invalid exxtra data fails
-        res = testapp.post('/taxonomies/', {'code': 'bad', 'extra_data': "{'extra': }"}, expect_errors=True)
+        res = testapp.post(
+            "/taxonomies/",
+            {"code": "bad", "extra_data": "{'extra': }"},
+            expect_errors=True,
+        )
         assert res.status_code == 400
 
         # Test duplicit create fails
-        res = testapp.post('/taxonomies/', {'code': root_taxonomy.code}, expect_errors=True)
+        res = testapp.post(
+            "/taxonomies/", {"code": root_taxonomy.code}, expect_errors=True
+        )
         assert res.status_code == 400
 
     def test_list_taxonomy_roots(self, testapp, root_taxonomy, manager):
         """Test listing of top-level taxonomy terms."""
 
         # Test empty taxonomy
-        res = testapp.get('/taxonomies/{}/'.format(root_taxonomy.code))
+        res = testapp.get("/taxonomies/{}/".format(root_taxonomy.code))
         jsonres = json.loads(res.body)
         assert jsonres == []
 
-        manager.create('top1', {'en': 'Top1'}, '/root/')
-        manager.create('leaf1', {'en': 'Leaf1'}, '/root/top1/')
-        manager.create('top2', {'en': 'Top2'}, '/root/')
+        manager.create("top1", {"en": "Top1"}, "/root/")
+        manager.create("leaf1", {"en": "Leaf1"}, "/root/top1/")
+        manager.create("top2", {"en": "Top2"}, "/root/")
 
         # Test multiple top-level terms
-        res = testapp.get('/taxonomies/{}/'.format(root_taxonomy.code))
+        res = testapp.get("/taxonomies/{}/".format(root_taxonomy.code))
         jsonres = json.loads(res.body)
         assert len(jsonres) == 2
-        slugs = [r['slug'] for r in jsonres]
-        assert 'top1' in slugs
-        assert 'top2' in slugs
-        assert 'leaf1' not in slugs
+        slugs = [r["slug"] for r in jsonres]
+        assert "top1" in slugs
+        assert "top2" in slugs
+        assert "leaf1" not in slugs
 
         # Test non-existent taxonomy
-        res = testapp.get('/taxonomies/blah/', expect_errors=True)
+        res = testapp.get("/taxonomies/blah/", expect_errors=True)
         assert res.status_code == 404
 
     def test_get_taxonomy_term(self, testapp, root_taxonomy, manager):
         """Test getting Term details."""
-        manager.create('top1', {'en': 'Top1'}, '/root/')
-        manager.create('leaf1', {'en': 'Leaf1'}, '/root/top1/')
-        manager.create('leafeaf', {'en': 'LeafOfLeaf'}, '/root/top1/leaf1')
+        manager.create("top1", {"en": "Top1"}, "/root/")
+        manager.create("leaf1", {"en": "Leaf1"}, "/root/top1/")
+        manager.create("leafeaf", {"en": "LeafOfLeaf"}, "/root/top1/leaf1")
 
-        res = testapp.get('/taxonomies/{}/top1/leaf1/'.format(root_taxonomy.code))
+        res = testapp.get("/taxonomies/{}/top1/leaf1/".format(root_taxonomy.code))
         jsonres = json.loads(res.body)
         assert isinstance(jsonres, dict)
-        assert jsonres['slug'] == 'leaf1'
-        assert jsonres['path'] == '/root/top1/leaf1'
-        assert len(jsonres['children']) == 1
+        assert jsonres["slug"] == "leaf1"
+        assert jsonres["path"] == "/root/top1/leaf1"
+        assert len(jsonres["children"]) == 1
 
         # Test get nonexistent path
-        res = testapp.get('/taxonomies/{}/top1/nope/'.format(root_taxonomy.code), expect_errors=True)
+        res = testapp.get(
+            "/taxonomies/{}/top1/nope/".format(root_taxonomy.code), expect_errors=True
+        )
         assert res.status_code == 404
 
     def test_term_create(self, root_taxonomy, testapp, manager):
         """Test TaxonomyTerm creation."""
-        res = testapp.post('/taxonomies/{}/leaf1/'.format(root_taxonomy.code), {'title': '{"en": "Leaf"}'})
+        res = testapp.post(
+            "/taxonomies/{}/leaf1/".format(root_taxonomy.code),
+            {"title": '{"en": "Leaf"}'},
+        )
         jsonres = json.loads(res.body)
         assert res.status_code == 201
-        assert jsonres['slug'] == 'leaf1'
+        assert jsonres["slug"] == "leaf1"
 
-        created = manager.get_term(root_taxonomy, 'leaf1')
-        assert created.title == {'en': 'Leaf'}
-        assert created.slug == 'leaf1'
+        created = manager.get_term(root_taxonomy, "leaf1")
+        assert created.title == {"en": "Leaf"}
+        assert created.slug == "leaf1"
         assert created.taxonomy == root_taxonomy
 
         # Test invalid path fails
-        res = testapp.post('/taxonomies/{}/top1/leaf1/'.format(root_taxonomy.code), {'title': '{"en": "Leaf"}'},
-                           expect_errors=True)
+        res = testapp.post(
+            "/taxonomies/{}/top1/leaf1/".format(root_taxonomy.code),
+            {"title": '{"en": "Leaf"}'},
+            expect_errors=True,
+        )
         assert res.status_code == 400
 
         # Test create on nested path
-        manager.create('top1', {'en': 'Top1'}, '/root/')
-        res = testapp.post('/taxonomies/{}/top1/leaf2/'.format(root_taxonomy.code), {'title': '{"en": "Leaf"}'})
+        manager.create("top1", {"en": "Top1"}, "/root/")
+        res = testapp.post(
+            "/taxonomies/{}/top1/leaf2/".format(root_taxonomy.code),
+            {"title": '{"en": "Leaf"}'},
+        )
         assert res.status_code == 201
 
-        created = manager.get_term(root_taxonomy, 'leaf2')
-        assert created.title == {'en': 'Leaf'}
-        assert created.slug == 'leaf2'
+        created = manager.get_term(root_taxonomy, "leaf2")
+        assert created.title == {"en": "Leaf"}
+        assert created.slug == "leaf2"
         assert created.taxonomy == root_taxonomy
 
         # Test create duplicit slug fails
-        res = testapp.post('/taxonomies/{}/leaf2/'.format(root_taxonomy.code), {'title': '{"en": "Leaf"}'},
-                           expect_errors=True)
+        res = testapp.post(
+            "/taxonomies/{}/leaf2/".format(root_taxonomy.code),
+            {"title": '{"en": "Leaf"}'},
+            expect_errors=True,
+        )
         assert res.status_code == 400
 
     def test_taxonomy_delete(self, db, root_taxonomy, manager, testapp):
         """Test deleting whole taxonomy."""
-        t = Taxonomy(code='tbd')
+        t = Taxonomy(code="tbd")
         db.session.add(t)
         db.session.commit()
 
-        manager.create('top1', {'en': 'Top1'}, '/tbd/')
-        manager.create('leaf1', {'en': 'Leaf1'}, '/tbd/top1/')
+        manager.create("top1", {"en": "Top1"}, "/tbd/")
+        manager.create("leaf1", {"en": "Leaf1"}, "/tbd/top1/")
 
-        res = testapp.delete('/taxonomies/tbd/')
+        res = testapp.delete("/taxonomies/tbd/")
         assert res.status_code == 204
-        assert manager.get_taxonomy('tbd') is None
-        assert manager.get_term(t, 'leaf1') is None
-        assert manager.get_term(t, 'top1') is None
+        assert manager.get_taxonomy("tbd") is None
+        assert manager.get_term(t, "leaf1") is None
+        assert manager.get_term(t, "top1") is None
 
         # Delete nonexistent taxonomy fails
-        res = testapp.delete('/taxonomies/nope/', expect_errors=True)
+        res = testapp.delete("/taxonomies/nope/", expect_errors=True)
         assert res.status_code == 404
 
     def test_term_delete(self, root_taxonomy, manager, testapp):
         """Test deleting whole term and a subtree."""
-        manager.create('top1', {'en': 'Top1'}, '/root/')
-        manager.create('leaf1', {'en': 'Leaf1'}, '/root/top1/')
-        manager.create('top2', {'en': 'Top2'}, '/root/')
+        manager.create("top1", {"en": "Top1"}, "/root/")
+        manager.create("leaf1", {"en": "Leaf1"}, "/root/top1/")
+        manager.create("top2", {"en": "Top2"}, "/root/")
 
-        testapp.delete('/taxonomies/root/top1/')
-        assert manager.get_term(root_taxonomy, 'leaf1') is None
-        assert manager.get_term(root_taxonomy, 'top1') is None
-        assert manager.get_term(root_taxonomy, 'top2') is not None
+        testapp.delete("/taxonomies/root/top1/")
+        assert manager.get_term(root_taxonomy, "leaf1") is None
+        assert manager.get_term(root_taxonomy, "top1") is None
+        assert manager.get_term(root_taxonomy, "top2") is not None
 
     def test_taxomomy_update(self, root_taxonomy, testapp, manager):
         """Test updating a taxonomy."""
-        res = testapp.patch('/taxonomies/root/', {'extra_data': '{"updated": "yes"}'})
+        res = testapp.patch("/taxonomies/root/", {"extra_data": '{"updated": "yes"}'})
         jsonres = json.loads(res.body)
         assert res.status_code == 200
-        assert jsonres['extra_data'] == {'updated': 'yes'}
-        assert manager.get_taxonomy('root').extra_data == {'updated': 'yes'}
+        assert jsonres["extra_data"] == {"updated": "yes"}
+        assert manager.get_taxonomy("root").extra_data == {"updated": "yes"}
 
         # Test update invalid taxonomy fails
-        res = testapp.patch('/taxonomies/nope/', {'extra_data': '{"updated": "yes"}'}, expect_errors=True)
+        res = testapp.patch(
+            "/taxonomies/nope/",
+            {"extra_data": '{"updated": "yes"}'},
+            expect_errors=True,
+        )
         assert res.status_code == 404
 
     def test_term_update(self, root_taxonomy, testapp, manager):
         """Test updating a term."""
-        manager.create('term1', {'en': 'Term1'}, '/root/')
+        manager.create("term1", {"en": "Term1"}, "/root/")
 
-        res = testapp.patch('/taxonomies/root/term1/', {'extra_data': '{"updated": "yes"}'})
+        res = testapp.patch(
+            "/taxonomies/root/term1/", {"extra_data": '{"updated": "yes"}'}
+        )
         jsonres = json.loads(res.body)
         assert res.status_code == 200
-        assert jsonres['extra_data'] == {'updated': 'yes'}
-        assert manager.get_term(root_taxonomy, 'term1').extra_data == {'updated': 'yes'}
+        assert jsonres["extra_data"] == {"updated": "yes"}
+        assert manager.get_term(root_taxonomy, "term1").extra_data == {"updated": "yes"}
 
-        res = testapp.patch('/taxonomies/root/term1/', {'title': '{"updated": "yes"}'})
+        res = testapp.patch("/taxonomies/root/term1/", {"title": '{"updated": "yes"}'})
         jsonres = json.loads(res.body)
         assert res.status_code == 200
-        assert jsonres['title'] == {'updated': 'yes'}
-        assert manager.get_term(root_taxonomy, 'term1').title == {'updated': 'yes'}
+        assert jsonres["title"] == {"updated": "yes"}
+        assert manager.get_term(root_taxonomy, "term1").title == {"updated": "yes"}
 
         # Test update invalid term fails
-        res = testapp.patch('/taxonomies/root/nope/', {'title': '{"updated": "yes"}'}, expect_errors=True)
+        res = testapp.patch(
+            "/taxonomies/root/nope/",
+            {"title": '{"updated": "yes"}'},
+            expect_errors=True,
+        )
         assert res.status_code == 404
 
     def test_term_move(self, db, root_taxonomy, testapp, manager):
         """Test moving a Taxonomy Term."""
-        t = Taxonomy(code='groot')
+        t = Taxonomy(code="groot")
         db.session.add(t)
         db.session.commit()
 
-        term1 = manager.create('term1', {'en': 'Term1'}, '/root/')
-        term2 = manager.create('term2', {'en': 'Term1'}, '/groot/')
+        manager.create("term1", {"en": "Term1"}, "/root/")
+        term2 = manager.create("term2", {"en": "Term1"}, "/groot/")
 
         # Test move /root/term1 -> /groot/term2/term1
-        res = testapp.patch('/taxonomies/root/term1/', {'move_target': '/groot/term2/'})
-        jsonres = json.loads(res.body)
+        res = testapp.patch("/taxonomies/root/term1/", {"move_target": "/groot/term2/"})
         assert res.status_code == 200
-        moved = manager.get_term(t, 'term1')
+        moved = manager.get_term(t, "term1")
         assert moved is not None
         assert moved.taxonomy == t
         assert moved.is_descendant_of(term2)
-        assert moved.tree_path == '/groot/term2/term1'
+        assert moved.tree_path == "/groot/term2/term1"
 
         # Test move subtree
-        res = testapp.patch('/taxonomies/groot/term2/', {'move_target': '/root/'})
+        res = testapp.patch("/taxonomies/groot/term2/", {"move_target": "/root/"})
         assert res.status_code == 200
 
-        moved1 = manager.get_term(root_taxonomy, 'term2')
-        moved2 = manager.get_term(root_taxonomy, 'term1')
+        moved1 = manager.get_term(root_taxonomy, "term2")
+        moved2 = manager.get_term(root_taxonomy, "term1")
 
-        assert moved1.tree_path == '/root/term2'
-        assert moved2.tree_path == '/root/term2/term1'
+        assert moved1.tree_path == "/root/term2"
+        assert moved2.tree_path == "/root/term2/term1"
         assert moved1.taxonomy == root_taxonomy
         assert moved2.taxonomy == root_taxonomy
         assert moved2.is_descendant_of(moved1)
 
         # Test move to invalid path fails
-        res = testapp.patch('/taxonomies/root/term2/', {'move_target': '/root/somethingbad/'}, expect_errors=True)
+        res = testapp.patch(
+            "/taxonomies/root/term2/",
+            {"move_target": "/root/somethingbad/"},
+            expect_errors=True,
+        )
         assert res.status_code == 400
 
         # Test move from invalid source fails
-        res = testapp.patch('/taxonomies/root/somethingbad/', {'move_target': '/groot/'}, expect_errors=True)
+        res = testapp.patch(
+            "/taxonomies/root/somethingbad/",
+            {"move_target": "/groot/"},
+            expect_errors=True,
+        )
         assert res.status_code == 404

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,213 +1,213 @@
-# -*- coding: utf-8 -*-
-"""Functional tests using WebTest.
-
-See: http://webtest.readthedocs.org/
-"""
-import json
-
-import pytest
-from webtest import AppError
-from werkzeug.exceptions import BadRequest
-
-from flask_taxonomies.models import Taxonomy
-from flask_taxonomies.views import slug_path_parent, slug_path_validator, slug_validator
-
-
-@pytest.mark.usefixtures("db")
-class TestTaxonomy:
-    """Taxonomy functional test."""
-
-    def test_slug_valdiator(self, root_taxonomy):
-        """Returns BadRequest on invalid/non-existent slugs."""
-        with pytest.raises(BadRequest):
-            slug_validator("nonexistent-slug")
-
-        assert slug_validator("root") is None
-
-    def test_slug_path_validator(self, db, root_taxonomy):
-        """Returns BadRequest on invalid/non-existent paths."""
-        leaf = Taxonomy(
-            slug="valid-path",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        with pytest.raises(BadRequest):
-            slug_path_validator("root/invalid-path")
-
-        assert slug_path_validator("root/valid-path") is None
-
-    def test_slug_path_parent(self, db, root_taxonomy):
-        """Returns last component of slug path as Taxonomy instance."""
-        leaf = Taxonomy(
-            slug="valid-path",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        returned = slug_path_parent("root/valid-path")
-        assert returned == returned
-
-    def test_taxonomy_list(self, db, root_taxonomy, testapp):
-        """Test listing of taxonomies."""
-        leaf = Taxonomy(
-            slug="valid-path",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        expected_root = {
-            "description": "Taxonomy root term",
-            "path": "root",
-            "slug": "root",
-            "id": 1,
-            "label": "<Taxonomy(root)>",
-            "title": '{"en": "Root"}',
-        }
-
-        expected_leaf = {
-            "description": "Taxonomy leaf term",
-            "path": "root/valid-path",
-            "slug": "valid-path",
-            "id": 2,
-            "label": "<Taxonomy(valid-path)>",
-            "title": '{"en": "Leaf"}',
-        }
-        expected_fulltree = expected_root.copy()
-        expected_fulltree.update({"children": [expected_leaf]})
-
-        # List top-level Taxonomy trees
-        res = testapp.get("/taxonomies/")
-        jsonres = json.loads(res.body)
-        assert jsonres == [expected_root]
-
-        # List full Taxonomy tree terms
-        res = testapp.get("/taxonomies/root/")
-        jsonres = json.loads(res.body)
-        assert jsonres == [expected_fulltree]
-
-    def test_taxonomy_create(self, root_taxonomy, testapp):
-        """Test Taxonomy creation."""
-        newtitle = {"en": "NEW"}
-
-        # Create on path
-        resp = testapp.post("/taxonomies/root/new/", {"title": json.dumps(newtitle)})
-        assert resp.status_code == 201
-
-        created: Taxonomy = Taxonomy.get_by_slug("new")
-        assert created.is_descendant_of(root_taxonomy)
-        assert created.title == json.dumps(newtitle)
-
-        # Create and attach to
-        resp = testapp.post(
-            "/taxonomies/new2/",
-            {"title": json.dumps(newtitle), "attach_to": root_taxonomy.slug},
-        )
-        assert resp.status_code == 201
-
-        created: Taxonomy = Taxonomy.get_by_slug("new2")
-        assert created.is_descendant_of(root_taxonomy)
-        assert created.title == json.dumps(newtitle)
-
-        # Both create on path and attach to fails
-        with pytest.raises(AppError) as ae:
-            testapp.post(
-                "/taxonomies/root/new3/",
-                {"title": json.dumps(newtitle), "attach_to": root_taxonomy.slug},
-            )
-            assert ae.error.code == 400
-
-    def test_taxonomy_delete(self, db, root_taxonomy, testapp):
-        """Test Taxonomy deletion."""
-        leaf = Taxonomy(
-            slug="valid-path",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        # Delete leaf
-        resp = testapp.delete("/taxonomies/valid-path/")
-        assert resp.status_code == 204
-
-        assert Taxonomy.get_by_slug("valid-path") is None
-
-        leaf = Taxonomy(
-            slug="valid-path",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        # Delete tree
-        resp = testapp.delete("/taxonomies/root/")
-        assert resp.status_code == 204
-
-        assert Taxonomy.get_by_slug("valid-path") is None
-        assert Taxonomy.get_by_slug("root") is None
-
-    def test_taxonomy_patch(self, root_taxonomy, testapp):
-        """Test update Taxonomy node."""
-        newtitle = json.dumps({"en": "patched"})
-        newdesc = "Patched"
-
-        resp = testapp.patch(
-            "/taxonomies/root/", {"title": newtitle, "description": newdesc}
-        )
-        assert resp.status_code == 200
-
-        patched = Taxonomy.get_by_slug("root")
-        assert patched.title == newtitle
-        assert patched.description == newdesc
-
-    def test_taxonomy_move(self, db, root_taxonomy, testapp):
-        """Test move ops on Taxonomy nodes.
-
-                   11
-        root - 1 <       ==>  root - 1 - 11 - 12
-                   12
-        """
-        leaf = Taxonomy(
-            slug="1",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(leaf)
-        db.session.commit()
-
-        subleaf1 = Taxonomy(
-            slug="11",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=leaf.id,
-        )
-        subleaf2 = Taxonomy(
-            slug="12",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=leaf.id,
-        )
-        db.session.add_all([subleaf1, subleaf2])
-        db.session.commit()
-
-        assert not subleaf2.is_descendant_of(subleaf1)
-
-        resp = testapp.post("/taxonomies/root/1/12/move", {"destination": "11"})
-        assert resp.status_code == 200
-
-        moved: Taxonomy = Taxonomy.get_by_slug("12")
-        assert moved.is_descendant_of(Taxonomy.get_by_slug("11"))
+# # -*- coding: utf-8 -*-
+# """Functional tests using WebTest.
+#
+# See: http://webtest.readthedocs.org/
+# """
+# import json
+#
+# import pytest
+# from webtest import AppError
+# from werkzeug.exceptions import BadRequest
+#
+# from flask_taxonomies.models import TaxonomyTerm
+# from flask_taxonomies.views import slug_path_parent, slug_path_validator, slug_validator
+#
+#
+# @pytest.mark.usefixtures("db")
+# class TestTaxonomy:
+#     """TaxonomyTerm functional test."""
+#
+#     def test_slug_valdiator(self, root_taxonomy):
+#         """Returns BadRequest on invalid/non-existent slugs."""
+#         with pytest.raises(BadRequest):
+#             slug_validator("nonexistent-slug")
+#
+#         assert slug_validator("root") is None
+#
+#     def test_slug_path_validator(self, db, root_taxonomy):
+#         """Returns BadRequest on invalid/non-existent paths."""
+#         leaf = TaxonomyTerm(
+#             slug="valid-path",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         with pytest.raises(BadRequest):
+#             slug_path_validator("root/invalid-path")
+#
+#         assert slug_path_validator("root/valid-path") is None
+#
+#     def test_slug_path_parent(self, db, root_taxonomy):
+#         """Returns last component of slug path as TaxonomyTerm instance."""
+#         leaf = TaxonomyTerm(
+#             slug="valid-path",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         returned = slug_path_parent("root/valid-path")
+#         assert returned == returned
+#
+#     def test_taxonomy_list(self, db, root_taxonomy, testapp):
+#         """Test listing of taxonomies."""
+#         leaf = TaxonomyTerm(
+#             slug="valid-path",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         expected_root = {
+#             "description": "TaxonomyTerm root term",
+#             "path": "root",
+#             "slug": "root",
+#             "id": 1,
+#             "label": "<TaxonomyTerm(root)>",
+#             "title": '{"en": "Root"}',
+#         }
+#
+#         expected_leaf = {
+#             "description": "TaxonomyTerm leaf term",
+#             "path": "root/valid-path",
+#             "slug": "valid-path",
+#             "id": 2,
+#             "label": "<TaxonomyTerm(valid-path)>",
+#             "title": '{"en": "Leaf"}',
+#         }
+#         expected_fulltree = expected_root.copy()
+#         expected_fulltree.update({"children": [expected_leaf]})
+#
+#         # List top-level TaxonomyTerm trees
+#         res = testapp.get("/taxonomies/")
+#         jsonres = json.loads(res.body)
+#         assert jsonres == [expected_root]
+#
+#         # List full TaxonomyTerm tree terms
+#         res = testapp.get("/taxonomies/root/")
+#         jsonres = json.loads(res.body)
+#         assert jsonres == [expected_fulltree]
+#
+#     def test_taxonomy_create(self, root_taxonomy, testapp):
+#         """Test TaxonomyTerm creation."""
+#         newtitle = {"en": "NEW"}
+#
+#         # Create on path
+#         resp = testapp.post("/taxonomies/root/new/", {"title": json.dumps(newtitle)})
+#         assert resp.status_code == 201
+#
+#         created: TaxonomyTerm = TaxonomyTerm.get_by_slug("new")
+#         assert created.is_descendant_of(root_taxonomy)
+#         assert created.title == json.dumps(newtitle)
+#
+#         # Create and attach to
+#         resp = testapp.post(
+#             "/taxonomies/new2/",
+#             {"title": json.dumps(newtitle), "attach_to": root_taxonomy.slug},
+#         )
+#         assert resp.status_code == 201
+#
+#         created: TaxonomyTerm = TaxonomyTerm.get_by_slug("new2")
+#         assert created.is_descendant_of(root_taxonomy)
+#         assert created.title == json.dumps(newtitle)
+#
+#         # Both create on path and attach to fails
+#         with pytest.raises(AppError) as ae:
+#             testapp.post(
+#                 "/taxonomies/root/new3/",
+#                 {"title": json.dumps(newtitle), "attach_to": root_taxonomy.slug},
+#             )
+#             assert ae.error.code == 400
+#
+#     def test_taxonomy_delete(self, db, root_taxonomy, testapp):
+#         """Test TaxonomyTerm deletion."""
+#         leaf = TaxonomyTerm(
+#             slug="valid-path",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         # Delete leaf
+#         resp = testapp.delete("/taxonomies/valid-path/")
+#         assert resp.status_code == 204
+#
+#         assert TaxonomyTerm.get_by_slug("valid-path") is None
+#
+#         leaf = TaxonomyTerm(
+#             slug="valid-path",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         # Delete tree
+#         resp = testapp.delete("/taxonomies/root/")
+#         assert resp.status_code == 204
+#
+#         assert TaxonomyTerm.get_by_slug("valid-path") is None
+#         assert TaxonomyTerm.get_by_slug("root") is None
+#
+#     def test_taxonomy_patch(self, root_taxonomy, testapp):
+#         """Test update TaxonomyTerm node."""
+#         newtitle = json.dumps({"en": "patched"})
+#         newdesc = "Patched"
+#
+#         resp = testapp.patch(
+#             "/taxonomies/root/", {"title": newtitle, "description": newdesc}
+#         )
+#         assert resp.status_code == 200
+#
+#         patched = TaxonomyTerm.get_by_slug("root")
+#         assert patched.title == newtitle
+#         assert patched.description == newdesc
+#
+#     def test_taxonomy_move(self, db, root_taxonomy, testapp):
+#         """Test move ops on TaxonomyTerm nodes.
+#
+#                    11
+#         root - 1 <       ==>  root - 1 - 11 - 12
+#                    12
+#         """
+#         leaf = TaxonomyTerm(
+#             slug="1",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=root_taxonomy.id,
+#         )
+#         db.session.add(leaf)
+#         db.session.commit()
+#
+#         subleaf1 = TaxonomyTerm(
+#             slug="11",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=leaf.id,
+#         )
+#         subleaf2 = TaxonomyTerm(
+#             slug="12",
+#             title='{"en": "Leaf"}',
+#             description="TaxonomyTerm leaf term",
+#             parent_id=leaf.id,
+#         )
+#         db.session.add_all([subleaf1, subleaf2])
+#         db.session.commit()
+#
+#         assert not subleaf2.is_descendant_of(subleaf1)
+#
+#         resp = testapp.post("/taxonomies/root/1/12/move", {"destination": "11"})
+#         assert resp.status_code == 200
+#
+#         moved: TaxonomyTerm = TaxonomyTerm.get_by_slug("12")
+#         assert moved.is_descendant_of(TaxonomyTerm.get_by_slug("11"))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -27,11 +27,13 @@ class TestTaxonomyAPI:
             "id": root_taxonomy.id,
             "code": root_taxonomy.code,
             "extra_data": root_taxonomy.extra_data,
+            "links": {"self": "http://localhost/taxonomies/root/"},
         } in jsonres
         assert {
             "id": additional.id,
             "code": additional.code,
             "extra_data": additional.extra_data,
+            "links": {"self": "http://localhost/taxonomies/additional/"},
         } in jsonres
 
     def test_create_taxonomy(self, testapp, root_taxonomy):

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Model unit tests."""
+import pytest
+
+from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+
+
+@pytest.mark.usefixtures('db')
+class TestTaxonomyManager:
+    """Taxonomy manager tests."""
+
+    def test_create_term(self, db, root_taxonomy, manager):
+        """TaxonomyTerm creation tests"""
+
+        # Test create valid term
+        created = manager.create(slug='child', title={'en': 'Leaf'}, path='/root/')
+
+        assert created.slug == 'child'
+        assert created.taxonomy == root_taxonomy
+
+        # Test create term on non-existing path fails
+        with pytest.raises(AttributeError):
+            created = manager.create(slug='child', title={'en': 'Leaf'}, path='/root/non-existent/')
+
+        # Test create term in non-existing taxonomy fails
+        with pytest.raises(AttributeError):
+            created = manager.create(slug='child', title={'en': 'Leaf'}, path='/nope/')
+
+        # Test create nested term
+        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        subleaf = manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/root/leaf/')
+        db.session.add(subleaf)
+        db.session.commit()
+
+        assert subleaf.slug == 'subleaf'
+        assert subleaf.taxonomy == root_taxonomy
+        assert subleaf.is_descendant_of(leaf)
+
+        # Test create duplicit term in same taxonomy fails
+        with pytest.raises(ValueError):
+            manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/root/leaf/')
+
+        # Test create duplicit term in different taxonomy
+        different = Taxonomy(code='different')
+        db.session.add(different)
+        db.session.commit()
+
+        created = manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/different/')
+        db.session.add(created)
+        db.session.commit()
+
+        assert created.slug == subleaf.slug
+        assert created.id != subleaf.id
+        assert created.taxonomy == different
+
+    def test_get_taxonomy(self, root_taxonomy, manager):
+        """Test get Taxonomy by codename."""
+        retrieved = manager.get_taxonomy('root')
+
+        assert retrieved == root_taxonomy
+
+    def test_get_term(self, db, root_taxonomy, manager):
+        """Test get terms associtated by taxonomy and slug."""
+        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        # Test simple slug get
+        retrieved = manager.get_term(root_taxonomy, 'leaf')
+        assert retrieved == leaf
+
+        # Test duplicit slug get
+        second_taxonomy = Taxonomy(code='second')
+        db.session.add(second_taxonomy)
+        db.session.commit()
+
+        dup_leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=second_taxonomy)
+        db.session.add(dup_leaf)
+        db.session.commit()
+
+        retrieved = manager.get_term(second_taxonomy, 'leaf')
+        assert retrieved == dup_leaf
+        assert retrieved != leaf
+
+    def test_get_from_path(self, db, root_taxonomy, manager):
+        """Test get taxonomy and term by its path in a taxonomy tree."""
+        leaf = TaxonomyTerm(slug="leaf", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        subleaf = TaxonomyTerm(slug='subleaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        subleaf.parent = leaf
+        db.session.add(leaf)
+        db.session.commit()
+
+        subsubleaf = TaxonomyTerm(slug='subsubleaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        subsubleaf.parent = subleaf
+        db.session.add(leaf)
+        db.session.commit()
+
+        # Test get root returns both None
+        root, term = manager.get_from_path('/')
+        assert root is None
+        assert term is None
+
+        # Test get taxonomy only
+        root, term = manager.get_from_path('/root')
+        assert root == root_taxonomy
+        assert term is None
+
+        # Test get both, toplevel term
+        root, term = manager.get_from_path('/root/leaf')
+        assert root == root_taxonomy
+        assert term == leaf
+
+        # Test get both, nested term
+        root, term = manager.get_from_path('/root/leaf/subleaf/subsubleaf')
+        assert root == root_taxonomy
+        assert term == subsubleaf
+
+        # Test get duplicit term
+        different = Taxonomy(code='different')
+        db.session.add(different)
+        db.session.commit()
+
+        created = manager.create(slug='leaf', title={'en': 'Leaf'}, path='/different/')
+        db.session.add(created)
+        db.session.commit()
+
+        root, term = manager.get_from_path('/different/leaf')
+        assert root == different
+        assert term == created
+        assert term != leaf
+
+    def test_move_tree(self, db, root_taxonomy, manager):
+        """Test moving a tree into another tree"""
+        manufacturer = Taxonomy(code='manufacturer')
+        item = TaxonomyTerm(slug="item", title={'en': 'Item'}, taxonomy=root_taxonomy)
+        vehicle = TaxonomyTerm(slug="vehicle", title={'en': 'Vehicle'}, taxonomy=root_taxonomy)
+
+        db.session.add(manufacturer)
+        db.session.add(item)
+        db.session.add(vehicle)
+        db.session.commit()
+
+        car = TaxonomyTerm(slug="car", title={'en': 'car'}, taxonomy=root_taxonomy)
+        car.parent = vehicle
+        db.session.add(car)
+        db.session.commit()
+
+        suv = TaxonomyTerm(slug='suv', title={'en': 'SUV'}, taxonomy=root_taxonomy)
+        suv.parent = car
+        db.session.add(suv)
+        db.session.commit()
+
+        # Test move in same taxonomy
+        manager.move_tree('/root/vehicle/car/', '/root/item/')
+
+        car = TaxonomyTerm.get_by_id(car.id)
+        suv = TaxonomyTerm.get_by_id(suv.id)
+        assert car.taxonomy == root_taxonomy
+        assert suv.taxonomy == root_taxonomy
+        assert car.is_descendant_of(item)
+        assert suv.is_descendant_of(car)
+
+        # Test move between taxonomies
+        manager.move_tree('/root/vehicle/', '/manufacturer/')
+
+        vehicle = TaxonomyTerm.get_by_id(vehicle.id)
+        assert vehicle.taxonomy == manufacturer
+
+    def test_delete_tree(self, db, root_taxonomy, manager):
+        """Test deleting existing TaxonomyTerm tree."""
+        vehicle = TaxonomyTerm(slug="vehicle", title={'en': 'Vehicle'}, taxonomy=root_taxonomy)
+        db.session.add(vehicle)
+        db.session.commit()
+
+        car = TaxonomyTerm(slug="car", title={'en': 'car'}, taxonomy=root_taxonomy)
+        car.parent = vehicle
+        db.session.add(car)
+        db.session.commit()
+
+        suv = TaxonomyTerm(slug='suv', title={'en': 'SUV'}, taxonomy=root_taxonomy)
+        suv.parent = car
+        db.session.add(suv)
+        db.session.commit()
+
+        assert car.is_descendant_of(vehicle)
+        assert suv.is_descendant_of(car)
+
+        manager.delete_tree('/root/vehicle/car/')
+
+        assert TaxonomyTerm.get_by_id(vehicle.id) == vehicle
+        assert TaxonomyTerm.get_by_id(car.id) is None
+        assert TaxonomyTerm.get_by_id(suv.id) is None
+
+        # Test delete invalid Term path fails
+        with pytest.raises(AttributeError):
+            manager.delete_tree('/root/')
+
+        with pytest.raises(AttributeError):
+            manager.delete_tree('/root/invalid/')

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -2,7 +2,7 @@
 """Model unit tests."""
 import pytest
 
-from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -5,52 +5,63 @@ import pytest
 from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures("db")
 class TestTaxonomyManager:
     """Taxonomy manager tests."""
 
     def test_create_term(self, db, root_taxonomy, manager):
-        """TaxonomyTerm creation tests"""
+        """Taxonomy Term creation tests."""
 
         # Test create valid term
-        created = manager.create(slug='child', extra_data={'extra': 'data'}, title={'en': 'Leaf'}, path='/root/')
+        created = manager.create(
+            slug="child",
+            extra_data={"extra": "data"},
+            title={"en": "Leaf"},
+            path="/root/",
+        )
 
         assert isinstance(created, TaxonomyTerm)
-        assert created.slug == 'child'
-        assert created.extra_data['extra'] == 'data'
+        assert created.slug == "child"
+        assert created.extra_data["extra"] == "data"
         assert created.taxonomy == root_taxonomy
 
         # Test create term on non-existing path fails
         with pytest.raises(AttributeError):
-            created = manager.create(slug='child', title={'en': 'Leaf'}, path='/root/non-existent/')
+            created = manager.create(
+                slug="child", title={"en": "Leaf"}, path="/root/non-existent/"
+            )
 
         # Test create term in non-existing taxonomy fails
         with pytest.raises(AttributeError):
-            created = manager.create(slug='child', title={'en': 'Leaf'}, path='/nope/')
+            created = manager.create(slug="child", title={"en": "Leaf"}, path="/nope/")
 
         # Test create nested term
-        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
-        subleaf = manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/root/leaf/')
+        subleaf = manager.create(
+            slug="subleaf", title={"en": "Leaf"}, path="/root/leaf/"
+        )
         db.session.add(subleaf)
         db.session.commit()
 
-        assert subleaf.slug == 'subleaf'
+        assert subleaf.slug == "subleaf"
         assert subleaf.taxonomy == root_taxonomy
         assert subleaf.is_descendant_of(leaf)
 
         # Test create duplicit term in same taxonomy fails
         with pytest.raises(ValueError):
-            manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/root/leaf/')
+            manager.create(slug="subleaf", title={"en": "Leaf"}, path="/root/leaf/")
 
         # Test create duplicit term in different taxonomy
-        different = Taxonomy(code='different')
+        different = Taxonomy(code="different")
         db.session.add(different)
         db.session.commit()
 
-        created = manager.create(slug='subleaf', title={'en': 'Leaf'}, path='/different/')
+        created = manager.create(
+            slug="subleaf", title={"en": "Leaf"}, path="/different/"
+        )
 
         assert created.slug == subleaf.slug
         assert created.id != subleaf.id
@@ -58,18 +69,19 @@ class TestTaxonomyManager:
 
     def test_get_taxonomy(self, root_taxonomy, manager):
         """Test get Taxonomy by codename."""
-        retrieved = manager.get_taxonomy('root')
+        retrieved = manager.get_taxonomy("root")
 
         assert isinstance(retrieved, Taxonomy)
         assert retrieved == root_taxonomy
 
         # Test nonexistent taxonomy
-        retrieved = manager.get_taxonomy(code='nothing')
+        retrieved = manager.get_taxonomy(code="nothing")
         assert retrieved is None
 
     def test_get_taxonomy_roots(self, root_taxonomy, manager):
-        topterm = manager.create(slug='top', title={'en': 'Top'}, path='/root/')
-        leafterm = manager.create(slug='leaf', title={'en': 'Leaf'}, path='/root/top/')
+        """Test get top-level taxonomy terms."""
+        topterm = manager.create(slug="top", title={"en": "Top"}, path="/root/")
+        manager.create(slug="leaf", title={"en": "Leaf"}, path="/root/top/")
 
         # Test single toplevel term
         root = list(manager.get_taxonomy_roots(root_taxonomy))
@@ -77,7 +89,9 @@ class TestTaxonomyManager:
         assert root[0] == topterm
 
         # Test multiple toplevel terms
-        anothertopterm = manager.create(slug='anothertop', title={'en': 'Another Top'}, path='/root/')
+        anothertopterm = manager.create(
+            slug="anothertop", title={"en": "Another Top"}, path="/root/"
+        )
         roots = list(manager.get_taxonomy_roots(root_taxonomy))
         assert len(roots) == 2
         assert topterm in roots
@@ -85,102 +99,110 @@ class TestTaxonomyManager:
 
     def test_get_term(self, db, root_taxonomy, manager):
         """Test get terms associtated by taxonomy and slug."""
-        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
         # Test simple slug get
-        retrieved = manager.get_term(root_taxonomy, 'leaf')
+        retrieved = manager.get_term(root_taxonomy, "leaf")
         assert retrieved == leaf
 
         # Test duplicit slug get
-        second_taxonomy = Taxonomy(code='second')
+        second_taxonomy = Taxonomy(code="second")
         db.session.add(second_taxonomy)
         db.session.commit()
 
-        dup_leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=second_taxonomy)
+        dup_leaf = TaxonomyTerm(
+            slug="leaf", title={"en": "Leaf"}, taxonomy=second_taxonomy
+        )
         db.session.add(dup_leaf)
         db.session.commit()
 
-        retrieved = manager.get_term(second_taxonomy, 'leaf')
+        retrieved = manager.get_term(second_taxonomy, "leaf")
         assert retrieved == dup_leaf
         assert retrieved != leaf
 
         # Test get invalid term fails
-        retrieved = manager.get_term(root_taxonomy, 'notterm')
+        retrieved = manager.get_term(root_taxonomy, "notterm")
         assert retrieved is None
 
     def test_get_from_path(self, db, root_taxonomy, manager):
         """Test get taxonomy and term by its path in a taxonomy tree."""
-        leaf = TaxonomyTerm(slug="leaf", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
-        subleaf = TaxonomyTerm(slug='subleaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        subleaf = TaxonomyTerm(
+            slug="subleaf", title={"en": "Leaf"}, taxonomy=root_taxonomy
+        )
         subleaf.parent = leaf
         db.session.add(leaf)
         db.session.commit()
 
-        subsubleaf = TaxonomyTerm(slug='subsubleaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        subsubleaf = TaxonomyTerm(
+            slug="subsubleaf", title={"en": "Leaf"}, taxonomy=root_taxonomy
+        )
         subsubleaf.parent = subleaf
         db.session.add(leaf)
         db.session.commit()
 
         # Test get root returns both None
-        root, term = manager.get_from_path('/')
+        root, term = manager.get_from_path("/")
         assert root is None
         assert term is None
 
         # Test get taxonomy only
-        root, term = manager.get_from_path('/root')
+        root, term = manager.get_from_path("/root")
         assert root == root_taxonomy
         assert term is None
 
         # Test get both, toplevel term
-        root, term = manager.get_from_path('/root/leaf')
+        root, term = manager.get_from_path("/root/leaf")
         assert root == root_taxonomy
         assert term == leaf
 
         # Test get both, nested term
-        root, term = manager.get_from_path('/root/leaf/subleaf/subsubleaf')
+        root, term = manager.get_from_path("/root/leaf/subleaf/subsubleaf")
         assert root == root_taxonomy
         assert term == subsubleaf
 
         # Test get duplicit term
-        different = Taxonomy(code='different')
+        different = Taxonomy(code="different")
         db.session.add(different)
         db.session.commit()
 
-        created = manager.create(slug='leaf', title={'en': 'Leaf'}, path='/different/')
+        created = manager.create(slug="leaf", title={"en": "Leaf"}, path="/different/")
 
-        root, term = manager.get_from_path('/different/leaf')
+        root, term = manager.get_from_path("/different/leaf")
         assert root == different
         assert term == created
         assert term != leaf
 
     def test_move_tree(self, db, root_taxonomy, manager):
-        """Test moving a tree into another tree"""
-        manufacturer = Taxonomy(code='manufacturer')
-        item = TaxonomyTerm(slug="item", title={'en': 'Item'}, taxonomy=root_taxonomy)
-        vehicle = TaxonomyTerm(slug="vehicle", title={'en': 'Vehicle'}, taxonomy=root_taxonomy)
+        """Test moving a tree into another tree."""
+        manufacturer = Taxonomy(code="manufacturer")
+        item = TaxonomyTerm(slug="item", title={"en": "Item"}, taxonomy=root_taxonomy)
+        vehicle = TaxonomyTerm(
+            slug="vehicle", title={"en": "Vehicle"}, taxonomy=root_taxonomy
+        )
 
         db.session.add(manufacturer)
         db.session.add(item)
         db.session.add(vehicle)
         db.session.commit()
 
-        car = TaxonomyTerm(slug="car", title={'en': 'car'}, taxonomy=root_taxonomy)
+        car = TaxonomyTerm(slug="car", title={"en": "car"}, taxonomy=root_taxonomy)
         car.parent = vehicle
         db.session.add(car)
         db.session.commit()
 
-        suv = TaxonomyTerm(slug='suv', title={'en': 'SUV'}, taxonomy=root_taxonomy)
+        suv = TaxonomyTerm(slug="suv", title={"en": "SUV"}, taxonomy=root_taxonomy)
         suv.parent = car
         db.session.add(suv)
         db.session.commit()
 
         # Test move in same taxonomy
-        manager.move_tree('/root/vehicle/car/', '/root/item/')
+        manager.move_tree("/root/vehicle/car/", "/root/item/")
 
         car = TaxonomyTerm.get_by_id(car.id)
         suv = TaxonomyTerm.get_by_id(suv.id)
@@ -190,27 +212,29 @@ class TestTaxonomyManager:
         assert suv.is_descendant_of(car)
 
         # Test move between taxonomies
-        manager.move_tree('/root/vehicle/', '/manufacturer/')
+        manager.move_tree("/root/vehicle/", "/manufacturer/")
 
         vehicle = TaxonomyTerm.get_by_id(vehicle.id)
         assert vehicle.taxonomy == manufacturer
 
         # Test move to invalid target path
         with pytest.raises(AttributeError):
-            manager.move_tree('/manufacturer/vehicle/', '/dump/')
+            manager.move_tree("/manufacturer/vehicle/", "/dump/")
 
     def test_delete_tree(self, db, root_taxonomy, manager):
         """Test deleting existing TaxonomyTerm tree."""
-        vehicle = TaxonomyTerm(slug="vehicle", title={'en': 'Vehicle'}, taxonomy=root_taxonomy)
+        vehicle = TaxonomyTerm(
+            slug="vehicle", title={"en": "Vehicle"}, taxonomy=root_taxonomy
+        )
         db.session.add(vehicle)
         db.session.commit()
 
-        car = TaxonomyTerm(slug="car", title={'en': 'car'}, taxonomy=root_taxonomy)
+        car = TaxonomyTerm(slug="car", title={"en": "car"}, taxonomy=root_taxonomy)
         car.parent = vehicle
         db.session.add(car)
         db.session.commit()
 
-        suv = TaxonomyTerm(slug='suv', title={'en': 'SUV'}, taxonomy=root_taxonomy)
+        suv = TaxonomyTerm(slug="suv", title={"en": "SUV"}, taxonomy=root_taxonomy)
         suv.parent = car
         db.session.add(suv)
         db.session.commit()
@@ -218,7 +242,7 @@ class TestTaxonomyManager:
         assert car.is_descendant_of(vehicle)
         assert suv.is_descendant_of(car)
 
-        manager.delete_tree('/root/vehicle/car/')
+        manager.delete_tree("/root/vehicle/car/")
 
         assert TaxonomyTerm.get_by_id(vehicle.id) == vehicle
         assert TaxonomyTerm.get_by_id(car.id) is None
@@ -226,7 +250,7 @@ class TestTaxonomyManager:
 
         # Test delete invalid Term path fails
         with pytest.raises(AttributeError):
-            manager.delete_tree('/root/')
+            manager.delete_tree("/root/")
 
         with pytest.raises(AttributeError):
-            manager.delete_tree('/root/invalid/')
+            manager.delete_tree("/root/invalid/")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,16 @@ from flask_taxonomies.models import TaxonomyTerm, Taxonomy
 class TestTaxonomy:
     """Taxonomy model tests."""
 
+    def test_create(self, db):
+        tax = Taxonomy(code='code', extra_data={'extra': 'data'})
+        db.session.add(tax)
+        db.session.commit()
+
+        retrieved = Taxonomy.get_by_id(tax.id)
+        assert retrieved.code == 'code'
+        assert retrieved.extra_data == {'extra': 'data'}
+
+
     def test_get_terms(self, db, root_taxonomy):
         """Get terms  listassocitated with this taxonomy."""
         leaf = TaxonomyTerm(slug="leaf", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
@@ -23,21 +33,6 @@ class TestTaxonomy:
         children = root_taxonomy.terms
         assert children == [leaf, nested]  #
 
-
-#
-@pytest.mark.usefixtures('db')
-class TestTaxonomyTerm:
-    """TaxonomyTerm Trees tests."""
-
-    def test_get_by_id(self, db, root_taxonomy):
-        """Get TaxonomyTerm Tree Items by ID."""
-        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
-        db.session.add(leaf)
-        db.session.commit()
-
-        retrieved_leaf = TaxonomyTerm.get_by_id((leaf.id))
-        assert retrieved_leaf == leaf
-
     def test_update_taxonomy(self, db, root_taxonomy):
         """Update Taxonomy extra_data."""
 
@@ -45,18 +40,6 @@ class TestTaxonomyTerm:
 
         retrieved_root = Taxonomy.get_by_id(root_taxonomy.id)
         assert retrieved_root.extra_data == {'description': 'updated'}
-
-    def test_update_taxonomy_term(self, db, root_taxonomy):
-        """Update TaxonomyTerm extra_data and name."""
-        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
-        db.session.add(leaf)
-        db.session.commit()
-
-        leaf.update(extra_data={'description': 'updated'}, title={'en': 'newleaf'})
-
-        retrieved_root = TaxonomyTerm.get_by_id(root_taxonomy.id)
-        assert retrieved_root.extra_data == {'description': 'updated'}
-        assert retrieved_root.title == {'en': 'newleaf'}
 
     def test_delete_taxonomy(self, db, root_taxonomy, manager):
         """Test deleting the whole Taxonomy."""
@@ -82,6 +65,32 @@ class TestTaxonomyTerm:
         assert Taxonomy.get_by_id(root_taxonomy.id) is None
         assert TaxonomyTerm.get_by_id(leaf.id) is None
         assert TaxonomyTerm.get_by_id(leaf2.id) is None
+
+
+@pytest.mark.usefixtures('db')
+class TestTaxonomyTerm:
+    """TaxonomyTerm model tests."""
+
+    def test_get_by_id(self, db, root_taxonomy):
+        """Get TaxonomyTerm Tree Items by ID."""
+        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        retrieved_leaf = TaxonomyTerm.get_by_id((leaf.id))
+        assert retrieved_leaf == leaf
+
+    def test_update_taxonomy_term(self, db, root_taxonomy):
+        """Update TaxonomyTerm extra_data and name."""
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        leaf.update(extra_data={'description': 'updated'}, title={'en': 'newleaf'})
+
+        retrieved_root = TaxonomyTerm.get_by_id(root_taxonomy.id)
+        assert retrieved_root.extra_data == {'description': 'updated'}
+        assert retrieved_root.title == {'en': 'newleaf'}
 
     def test_term_tree_path(self, db, root_taxonomy):
         """Test getting full path of a Term."""
@@ -122,4 +131,3 @@ class TestTaxonomyTerm:
         db.session.commit()
 
         assert TaxonomyTerm.get_by_id(leaf.id) is None
-#

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 """Model unit tests."""
 import pytest
 
-from flask_taxonomies.models import TaxonomyTerm, Taxonomy
+from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,27 +5,29 @@ import pytest
 from flask_taxonomies.models import Taxonomy, TaxonomyTerm
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures("db")
 class TestTaxonomy:
     """Taxonomy model tests."""
 
     def test_create(self, db):
-        tax = Taxonomy(code='code', extra_data={'extra': 'data'})
+        """Test create taxonomy."""
+        tax = Taxonomy(code="code", extra_data={"extra": "data"})
         db.session.add(tax)
         db.session.commit()
 
         retrieved = Taxonomy.get_by_id(tax.id)
-        assert retrieved.code == 'code'
-        assert retrieved.extra_data == {'extra': 'data'}
-
+        assert retrieved.code == "code"
+        assert retrieved.extra_data == {"extra": "data"}
 
     def test_get_terms(self, db, root_taxonomy):
         """Get terms  listassocitated with this taxonomy."""
-        leaf = TaxonomyTerm(slug="leaf", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
-        nested = TaxonomyTerm(slug="nested", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        nested = TaxonomyTerm(
+            slug="nested", title={"en": "Leaf"}, taxonomy=root_taxonomy
+        )
         nested.parent = leaf
         db.session.add(nested)
         db.session.commit()
@@ -36,24 +38,24 @@ class TestTaxonomy:
     def test_update_taxonomy(self, db, root_taxonomy):
         """Update Taxonomy extra_data."""
 
-        root_taxonomy.update(extra_data={'description': 'updated'})
+        root_taxonomy.update(extra_data={"description": "updated"})
 
         retrieved_root = Taxonomy.get_by_id(root_taxonomy.id)
-        assert retrieved_root.extra_data == {'description': 'updated'}
+        assert retrieved_root.extra_data == {"description": "updated"}
 
     def test_delete_taxonomy(self, db, root_taxonomy, manager):
         """Test deleting the whole Taxonomy."""
         leaf = TaxonomyTerm(
-            slug='leaf',
-            title={'en': 'Leaf'},
-            extra_data={'description': 'TaxonomyTerm leaf term'},
-            taxonomy=root_taxonomy
+            slug="leaf",
+            title={"en": "Leaf"},
+            extra_data={"description": "TaxonomyTerm leaf term"},
+            taxonomy=root_taxonomy,
         )
         leaf2 = TaxonomyTerm(
-            slug='leaf',
-            title={'en': 'Leaf'},
-            extra_data={'description': 'TaxonomyTerm leaf term'},
-            taxonomy=root_taxonomy
+            slug="leaf",
+            title={"en": "Leaf"},
+            extra_data={"description": "TaxonomyTerm leaf term"},
+            taxonomy=root_taxonomy,
         )
         db.session.add(leaf)
         db.session.add(leaf2)
@@ -67,13 +69,13 @@ class TestTaxonomy:
         assert TaxonomyTerm.get_by_id(leaf2.id) is None
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures("db")
 class TestTaxonomyTerm:
     """TaxonomyTerm model tests."""
 
     def test_get_by_id(self, db, root_taxonomy):
         """Get TaxonomyTerm Tree Items by ID."""
-        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
@@ -86,43 +88,43 @@ class TestTaxonomyTerm:
         db.session.add(leaf)
         db.session.commit()
 
-        leaf.update(extra_data={'description': 'updated'}, title={'en': 'newleaf'})
+        leaf.update(extra_data={"description": "updated"}, title={"en": "newleaf"})
 
         retrieved_root = TaxonomyTerm.get_by_id(root_taxonomy.id)
-        assert retrieved_root.extra_data == {'description': 'updated'}
-        assert retrieved_root.title == {'en': 'newleaf'}
+        assert retrieved_root.extra_data == {"description": "updated"}
+        assert retrieved_root.title == {"en": "newleaf"}
 
     def test_term_tree_path(self, db, root_taxonomy):
         """Test getting full path of a Term."""
         leaf = TaxonomyTerm(
-            slug='leaf',
-            title={'en': 'Leaf'},
-            extra_data={'description': 'TaxonomyTerm leaf term'},
-            taxonomy=root_taxonomy
+            slug="leaf",
+            title={"en": "Leaf"},
+            extra_data={"description": "TaxonomyTerm leaf term"},
+            taxonomy=root_taxonomy,
         )
         db.session.add(leaf)
         db.session.commit()
 
         nested = TaxonomyTerm(
-            slug='nested',
-            title={'en': 'Nested'},
-            extra_data={'description': 'Nested TaxonomyTerm'},
-            taxonomy=root_taxonomy
+            slug="nested",
+            title={"en": "Nested"},
+            extra_data={"description": "Nested TaxonomyTerm"},
+            taxonomy=root_taxonomy,
         )
         nested.parent = leaf
         db.session.add(nested)
         db.session.commit()
 
-        assert leaf.tree_path == '/root/leaf'
-        assert nested.tree_path == '/root/leaf/nested'
+        assert leaf.tree_path == "/root/leaf"
+        assert nested.tree_path == "/root/leaf/nested"
 
     def test_delete_taxonomy_term(self, db, root_taxonomy):
         """Delete single TaxonomyTerm term."""
         leaf = TaxonomyTerm(
-            slug='leaf',
-            title={'en': 'Leaf'},
-            extra_data={'description': 'TaxonomyTerm leaf term'},
-            taxonomy=root_taxonomy
+            slug="leaf",
+            title={"en": "Leaf"},
+            extra_data={"description": "TaxonomyTerm leaf term"},
+            taxonomy=root_taxonomy,
         )
         db.session.add(leaf)
         db.session.commit()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,153 +2,124 @@
 """Model unit tests."""
 import pytest
 
-from flask_taxonomies.models import Taxonomy
+from flask_taxonomies.models import TaxonomyTerm, Taxonomy
 
 
-@pytest.mark.usefixtures("db")
+@pytest.mark.usefixtures('db')
 class TestTaxonomy:
-    """Taxonomy Trees tests."""
+    """Taxonomy model tests."""
+
+    def test_get_terms(self, db, root_taxonomy):
+        """Get terms  listassocitated with this taxonomy."""
+        leaf = TaxonomyTerm(slug="leaf", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        nested = TaxonomyTerm(slug="nested", title={'en': 'Leaf'}, taxonomy=root_taxonomy)
+        nested.parent = leaf
+        db.session.add(nested)
+        db.session.commit()
+
+        children = root_taxonomy.terms
+        assert children == [leaf, nested]  #
+
+
+#
+@pytest.mark.usefixtures('db')
+class TestTaxonomyTerm:
+    """TaxonomyTerm Trees tests."""
 
     def test_get_by_id(self, db, root_taxonomy):
-        """Get Taxonomy Tree Items by ID."""
-        leaf = Taxonomy(
-            slug="leaf", title='{"en": "Leaf"}', description="Taxonomy leaf term"
-        )
-
+        """Get TaxonomyTerm Tree Items by ID."""
+        leaf = TaxonomyTerm(slug='leaf', title={'en': 'Leaf'}, taxonomy=root_taxonomy)
         db.session.add(leaf)
         db.session.commit()
 
-        retrieved_root = Taxonomy.get_by_id(root_taxonomy.id)
-        assert retrieved_root == root_taxonomy
-        retrieved_leaf = Taxonomy.get_by_id((leaf.id))
+        retrieved_leaf = TaxonomyTerm.get_by_id((leaf.id))
         assert retrieved_leaf == leaf
-
-    def test_get_by_slug(self, db, root_taxonomy):
-        """Get Taxonomy Tree Items by ID."""
-        leaf = Taxonomy(
-            slug="leaf", title='{"en": "Leaf"}', description="Taxonomy leaf term"
-        )
-
-        db.session.add(leaf)
-        db.session.commit()
-
-        retrieved_root = Taxonomy.get_by_slug("root")
-        assert retrieved_root == root_taxonomy
-        retrieved_leaf = Taxonomy.get_by_slug(("leaf"))
-        assert retrieved_leaf == leaf
-
-    def test_insert_term(self, db, root_taxonomy):
-        """Insert Taxonomy term into a tree."""
-        leaf = Taxonomy(
-            slug="leaf",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
-        )
-
-        db.session.add(leaf)
-        db.session.commit()
-        print(root_taxonomy.drilldown_tree())
-        assert leaf.is_descendant_of(root_taxonomy)
 
     def test_update_taxonomy(self, db, root_taxonomy):
-        """Update Taxonomy description and name."""
-        root_taxonomy.description = "updated"
-        root_taxonomy.slug = "updatev1"
-        root_taxonomy.title = '{"en": "orig", "_":"update"}'
+        """Update Taxonomy extra_data."""
 
-        db.session.add(root_taxonomy)
-        db.session.commit()
+        root_taxonomy.update(extra_data={'description': 'updated'})
 
         retrieved_root = Taxonomy.get_by_id(root_taxonomy.id)
-        assert retrieved_root.description == "updated"
-        assert retrieved_root.slug == "updatev1"
-        assert retrieved_root.title == '{"en": "orig", "_":"update"}'
+        assert retrieved_root.extra_data == {'description': 'updated'}
 
-    def test_move_tree(self, db, root_taxonomy):
-        """Move existing Taxonomy tree under another tree."""
-        vehicle = Taxonomy(
-            slug="vehicle",
-            title='{"en": "vehicle"}',
-            description="Vehicle",
-            parent_id=root_taxonomy.id,
+    def test_update_taxonomy_term(self, db, root_taxonomy):
+        """Update TaxonomyTerm extra_data and name."""
+        leaf = TaxonomyTerm(slug="leaf", title={"en": "Leaf"}, taxonomy=root_taxonomy)
+        db.session.add(leaf)
+        db.session.commit()
+
+        leaf.update(extra_data={'description': 'updated'}, title={'en': 'newleaf'})
+
+        retrieved_root = TaxonomyTerm.get_by_id(root_taxonomy.id)
+        assert retrieved_root.extra_data == {'description': 'updated'}
+        assert retrieved_root.title == {'en': 'newleaf'}
+
+    def test_delete_taxonomy(self, db, root_taxonomy, manager):
+        """Test deleting the whole Taxonomy."""
+        leaf = TaxonomyTerm(
+            slug='leaf',
+            title={'en': 'Leaf'},
+            extra_data={'description': 'TaxonomyTerm leaf term'},
+            taxonomy=root_taxonomy
         )
-        db.session.add(vehicle)
-        db.session.commit()
-
-        car = Taxonomy(slug="car", title='{"en": "car"}', description="Car")
-        db.session.add(car)
-        db.session.commit()
-
-        suv = Taxonomy(
-            slug="suv", title='{"en": "SUV"}', description="SUV", parent_id=car.id
+        leaf2 = TaxonomyTerm(
+            slug='leaf',
+            title={'en': 'Leaf'},
+            extra_data={'description': 'TaxonomyTerm leaf term'},
+            taxonomy=root_taxonomy
         )
-        db.session.add(suv)
+        db.session.add(leaf)
+        db.session.add(leaf2)
         db.session.commit()
 
-        assert vehicle.is_descendant_of(root_taxonomy)
-        assert not vehicle.is_ancestor_of(car)
-        assert not vehicle.is_ancestor_of(suv)
-
-        car.move_inside(vehicle.id)
-
-        db.session.add(car)
+        db.session.delete(root_taxonomy)
         db.session.commit()
 
-        assert vehicle.is_ancestor_of(car)
-        assert vehicle.is_ancestor_of(suv)
-        assert car.is_descendant_of(vehicle)
-        assert suv.is_descendant_of(car)
+        assert Taxonomy.get_by_id(root_taxonomy.id) is None
+        assert TaxonomyTerm.get_by_id(leaf.id) is None
+        assert TaxonomyTerm.get_by_id(leaf2.id) is None
 
-    def test_delete_taxonomy(self, db, root_taxonomy):
-        """Delete single Taxonomy term."""
-        leaf = Taxonomy(
-            slug="leaf",
-            title='{"en": "Leaf"}',
-            description="Taxonomy leaf term",
-            parent_id=root_taxonomy.id,
+    def test_term_tree_path(self, db, root_taxonomy):
+        """Test getting full path of a Term."""
+        leaf = TaxonomyTerm(
+            slug='leaf',
+            title={'en': 'Leaf'},
+            extra_data={'description': 'TaxonomyTerm leaf term'},
+            taxonomy=root_taxonomy
         )
         db.session.add(leaf)
         db.session.commit()
 
-        assert root_taxonomy.is_ancestor_of(leaf)
+        nested = TaxonomyTerm(
+            slug='nested',
+            title={'en': 'Nested'},
+            extra_data={'description': 'Nested TaxonomyTerm'},
+            taxonomy=root_taxonomy
+        )
+        nested.parent = leaf
+        db.session.add(nested)
+        db.session.commit()
+
+        assert leaf.tree_path == '/root/leaf'
+        assert nested.tree_path == '/root/leaf/nested'
+
+    def test_delete_taxonomy_term(self, db, root_taxonomy):
+        """Delete single TaxonomyTerm term."""
+        leaf = TaxonomyTerm(
+            slug='leaf',
+            title={'en': 'Leaf'},
+            extra_data={'description': 'TaxonomyTerm leaf term'},
+            taxonomy=root_taxonomy
+        )
+        db.session.add(leaf)
+        db.session.commit()
 
         db.session.delete(leaf)
         db.session.commit()
 
-        assert not root_taxonomy.is_ancestor_of(leaf)
-        assert not leaf.is_descendant_of(root_taxonomy)
-
-    def test_delete_tree(self, db, root_taxonomy):
-        """Move existing Taxonomy tree under another tree."""
-        vehicle = Taxonomy(
-            slug="vehicle",
-            title='{"en": "vehicle"}',
-            description="Vehicle",
-            parent_id=root_taxonomy.id,
-        )
-        db.session.add(vehicle)
-        db.session.commit()
-
-        car = Taxonomy(
-            slug="car", title='{"en": "car"}', description="Car", parent_id=vehicle.id
-        )
-        db.session.add(car)
-        db.session.commit()
-
-        suv = Taxonomy(
-            slug="suv", title='{"en": "SUV"}', description="SUV", parent_id=car.id
-        )
-        db.session.add(suv)
-        db.session.commit()
-
-        assert vehicle.is_descendant_of(root_taxonomy)
-        assert car.is_descendant_of(vehicle)
-        assert suv.is_descendant_of(car)
-
-        db.session.delete(car)
-        db.session.commit()
-
-        assert vehicle.is_descendant_of(root_taxonomy)
-        assert not car.is_descendant_of(vehicle)
-        assert not suv.is_descendant_of(vehicle)
+        assert TaxonomyTerm.get_by_id(leaf.id) is None
+#


### PR DESCRIPTION
This pull request splits the data model into Taxonomy and TaxonomyTerm, with full CRUD coverage for both models. This also allows to have Terms with duplicit slugs, but in different taxonomies. Additional metadata field is also added

Addresses #12 and #11 