### PR TITLE
refactor most operations to api, integrate with oarepo-references

### DIFF
--- a/flask_taxonomies/api.py
+++ b/flask_taxonomies/api.py
@@ -62,7 +62,7 @@ class TaxonomyAPI(object):
     def delete_taxonomy(cls, taxonomy: Taxonomy):
         """Delete a taxonomy.
         :param taxonomy: taxonomy instance to be deleted
-        :raise ReferenceError
+        :raise TaxonomyDeleteError
         """
         before_taxonomy_deleted.send(taxonomy, taxonomy=taxonomy)
         check_references_before_delete(taxonomy, taxonomy=taxonomy)
@@ -200,7 +200,7 @@ class TaxonomyAPI(object):
         """Delete a taxonomy term.
         :param taxonomy: taxonomy of the term
         :param term: term instance to be deleted
-        :raise ReferenceError
+        :raise TaxonomyDeleteError
         """
         before_taxonomy_term_deleted.send(term, taxonomy=taxonomy, term=term)
         check_references_before_delete(term, taxonomy=taxonomy, term=term)

--- a/flask_taxonomies/api.py
+++ b/flask_taxonomies/api.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Miroslav Bauer, CESNET.
+#
+# flask-taxonomies is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Taxonomy API"""
+
+from __future__ import absolute_import, print_function
+
+from flask import current_app, url_for
+from invenio_db import db
+from slugify import slugify
+from sqlalchemy.exc import IntegrityError
+
+from flask_taxonomies.models import Taxonomy, before_taxonomy_created, after_taxonomy_created, \
+    before_taxonomy_term_moved, MovePosition, after_taxonomy_term_moved, TaxonomyTerm, after_taxonomy_term_created, \
+    before_taxonomy_term_created, before_taxonomy_deleted, after_taxonomy_deleted, before_taxonomy_term_deleted, \
+    after_taxonomy_term_deleted, before_taxonomy_updated, after_taxonomy_updated, before_taxonomy_term_updated, \
+    after_taxonomy_term_updated
+from flask_taxonomies.signals import check_references_before_delete
+
+
+class TaxonomyAPI(object):
+    """Represents a taxonomy API.
+    """
+    @classmethod
+    def taxonomy_list(cls):
+        """Return a list of all available taxonomies."""
+        return Taxonomy.taxonomies()
+
+    @classmethod
+    def create_taxonomy(cls, code, extra_data=None) -> Taxonomy:
+        """Creates a new taxonomy.
+        :param code: taxonomy code
+        :param extra_data: taxonomy metadata
+        :raises IntegrityError
+        :returns Taxonomy
+        """
+        before_taxonomy_created.send(current_app._get_current_object(),
+                                     code=code, extra_data=extra_data)
+        created = Taxonomy.create_taxonomy(code=code, extra_data=extra_data)
+        db.session.commit()
+        after_taxonomy_created.send(created)
+        return created
+
+    @classmethod
+    def update_taxonomy(cls, taxonomy: Taxonomy, extra_data) -> Taxonomy:
+        """Updates a taxonomy.
+        :param taxonomy: taxonomy instance to be updated
+        :param extra_data: new taxonomy metadata
+        :return Taxonomy: updated taxonomy
+        """
+        before_taxonomy_updated.send(taxonomy, taxonomy=taxonomy, extra_data=extra_data)
+        taxonomy.update(extra_data)
+        db.session.commit()
+        after_taxonomy_updated.send(taxonomy, taxonomy=taxonomy)
+        return taxonomy
+
+    @classmethod
+    def delete_taxonomy(cls, taxonomy: Taxonomy):
+        """Delete a taxonomy.
+        :param taxonomy: taxonomy instance to be deleted
+        :raise ReferenceError
+        """
+        before_taxonomy_deleted.send(taxonomy, taxonomy=taxonomy)
+        check_references_before_delete(taxonomy, taxonomy=taxonomy)
+        taxonomy.delete()
+        db.session.commit()
+        after_taxonomy_deleted.send(taxonomy)
+
+    @classmethod
+    def move_term(cls, taxonomy, term_path='', target_path=None, destination_order=''):
+        """Moves a taxonomy term to a different path.
+        :param taxonomy: source taxonomy instance
+        :param term_path: current path of a term
+        :param target_path: desired path of a term
+        :param destination_order: order in a destination tree
+        :raise AttributeError
+        :raise NoResultFound
+        :return Tuple(Taxonomy, Taxonomy, Optional[Taxonomy]): target taxonomy and moved term
+        """
+        term = taxonomy.find_term(term_path)
+        if not term:
+            raise AttributeError('Invalid Term path given.')
+
+        before_taxonomy_term_moved.send(
+            term, taxonomy=taxonomy,
+            target_path=target_path, order=destination_order)
+
+        if not target_path:
+            target_path = f'{taxonomy.code}/'
+
+        target_taxonomy, target_term = Taxonomy.find_taxonomy_and_term(target_path)
+
+        term.move(target_term, position=MovePosition(destination_order or 'inside'))
+        db.session.commit()
+
+        after_taxonomy_term_moved.send(term, taxonomy=taxonomy)
+        db.session.refresh(term)
+        return (term, target_taxonomy, target_term)
+
+    @classmethod
+    def create_term(cls, taxonomy, term_path='', slug=None, extra_data=None) -> TaxonomyTerm:
+        """Creates a taxonomy term.
+        :param taxonomy: taxonomy in which to create a term
+        :param term_path: path on which to create a term
+        :param slug: term slug
+        :param extra_data: term metadata]
+        :raise AttributeError
+        :raise IntegrityError
+        :return TaxonomyTerm
+        """
+        term = taxonomy.find_term(term_path)
+        if not term:
+            raise AttributeError('Invalid Term path given.')
+
+        try:
+            slug = slugify(slug)
+            before_taxonomy_term_created.send(taxonomy, slug=slug, extra_data=extra_data)
+            created = term.create_term(slug=slug, extra_data=extra_data)
+            db.session.commit()
+            after_taxonomy_term_created.send(term, taxonomy=taxonomy)
+            return created
+        except IntegrityError as ie:
+            db.session.rollback()
+            raise ie
+
+    def term_links(self, taxonomy_code: str, path: str, parent_path: str=None):
+        """Return a reference URIs for a given term."""
+        links = {
+            "self": url_for(
+                "taxonomies.taxonomy_get_term",
+                taxonomy_code=taxonomy_code,
+                term_path=path[1:],
+                _external=True,
+            ),
+            "tree": url_for(
+                "taxonomies.taxonomy_get_term",
+                taxonomy_code=taxonomy_code,
+                term_path=path[1:],
+                drilldown=True,
+                _external=True,
+            )
+        }
+        if parent_path is not None:
+            if parent_path != '':
+                txc = taxonomy_code + parent_path
+                txc = txc.split('/', maxsplit=1)
+                links.update({
+                    "parent": url_for(
+                        "taxonomies.taxonomy_get_term",
+                        taxonomy_code=txc[0],
+                        term_path=txc[1],
+                        _external=True,
+                    ),
+                    "parent_tree": url_for(
+                        "taxonomies.taxonomy_get_term",
+                        taxonomy_code=txc[0],
+                        term_path=txc[1],
+                        drilldown=True,
+                        _external=True,
+                    )
+                })
+            else:
+                # parent is a taxonomy
+                links.update({
+                    "parent": url_for(
+                        "taxonomies.taxonomy_get_roots",
+                        taxonomy_code=taxonomy_code,
+                        _external=True,
+                    ),
+                    "parent_tree": url_for(
+                        "taxonomies.taxonomy_get_roots",
+                        taxonomy_code=taxonomy_code,
+                        drilldown=True,
+                        _external=True,
+                    )
+                })
+
+        return links
+
+    @classmethod
+    def update_term(cls, taxonomy: Taxonomy, term: TaxonomyTerm, changes) -> TaxonomyTerm:
+        """Updates a taxonomy term.
+        :param taxonomy: taxonomy instance of the term
+        :param term: term instance to be updated
+        :param extra_data: new term metadata
+        :return TaxonomyTerm: updated taxonomy term
+        """
+        before_taxonomy_term_updated.send(term, term=term, taxonomy=taxonomy, extra_data=changes['extra_data'])
+        term.update(**changes)
+        db.session.commit()
+        after_taxonomy_term_updated.send(term, term=term, taxonomy=taxonomy)
+        return term
+
+    @classmethod
+    def delete_term(cls, taxonomy: Taxonomy, term: TaxonomyTerm):
+        """Delete a taxonomy term.
+        :param taxonomy: taxonomy of the term
+        :param term: term instance to be deleted
+        :raise ReferenceError
+        """
+        before_taxonomy_term_deleted.send(term, taxonomy=taxonomy, term=term)
+        check_references_before_delete(term, taxonomy=taxonomy, term=term)
+        term.delete()
+        db.session.commit()
+        after_taxonomy_term_deleted.send(term, taxonomy=taxonomy, term=term)
+
+    @classmethod
+    def reindex_referencing_records(cls, reference):
+        pass
+
+
+__all__ = (
+    'TaxonomyAPI',
+)

--- a/flask_taxonomies/cli.py
+++ b/flask_taxonomies/cli.py
@@ -20,6 +20,7 @@ from flask_taxonomies.permissions import (
     taxonomy_term_update_all,
     taxonomy_update_all,
 )
+from flask_taxonomies.proxies import current_flask_taxonomies
 
 
 @click.group()
@@ -67,7 +68,7 @@ def import_taxonomy(taxonomy_file, int_conversions, str_args, drop):
 @taxonomies.command('list')
 @with_appcontext
 def list_taxonomies():
-    for t in Taxonomy.taxonomies():
+    for t in current_flask_taxonomies.taxonomy_list():
         print(t.code)
 
 
@@ -76,5 +77,4 @@ def list_taxonomies():
 @with_appcontext
 def delete_taxonomy(code):
     t = Taxonomy.get(code)
-    db.session.delete(t)
-    db.session.commit()
+    current_flask_taxonomies.delete_taxonomy(t)

--- a/flask_taxonomies/cli.py
+++ b/flask_taxonomies/cli.py
@@ -1,8 +1,6 @@
 import click
-from flask import current_app
 from flask.cli import with_appcontext
 from invenio_access import ActionSystemRoles, any_user
-from invenio_accounts.models import Role, User
 from invenio_db import db
 
 #

--- a/flask_taxonomies/errors.py
+++ b/flask_taxonomies/errors.py
@@ -1,0 +1,14 @@
+
+class TaxonomyDeleteError(Exception):
+    """Taxonomy deletion error."""
+    def __init__(self, message, records, *args, **kwargs):
+        self.message = message
+        self._records = records
+
+    @property
+    def records(self):
+        return [r.record_uuid for r in self._records]
+
+    def __repr__(self):
+        return self.message
+

--- a/flask_taxonomies/ext.py
+++ b/flask_taxonomies/ext.py
@@ -3,7 +3,10 @@
 from werkzeug.utils import cached_property
 
 from flask_taxonomies import config
-from flask_taxonomies.permissions import permission_factory
+from flask_taxonomies.api import TaxonomyAPI
+from flask_taxonomies.models import after_taxonomy_updated, before_taxonomy_deleted, after_taxonomy_term_moved, \
+    after_taxonomy_term_updated, before_taxonomy_term_deleted
+from flask_taxonomies.signals import reindex_referencing_records, check_references_before_delete
 from flask_taxonomies.utils import load_or_import_from_config
 
 
@@ -13,6 +16,35 @@ class _FlaskTaxonomiesState(object):
     def __init__(self, app):
         """Initialize state."""
         self.app = app
+        self.api = TaxonomyAPI()
+
+    def taxonomy_list(self):
+        return self.api.taxonomy_list()
+
+    def create_taxonomy(self, code, extra_data=None):
+        return self.api.create_taxonomy(code, extra_data)
+
+    def update_taxonomy(self, taxonomy, extra_data):
+        return self.api.update_taxonomy(taxonomy, extra_data)
+
+    def delete_taxonomy(self, taxonomy):
+        self.api.delete_taxonomy(taxonomy)
+
+    def move_term(self, taxonomy, term_path='', target_path=None, destination_order=''):
+        return self.api.move_term(taxonomy, term_path, target_path, destination_order)
+
+    def create_term(self, taxonomy, term_path='', slug=None, extra_data=None):
+        return self.api.create_term(taxonomy, term_path, slug, extra_data)
+
+    def term_links(self, taxonomy_code: str, path: str=None, parent_path: str=None):
+        return self.api.term_links(taxonomy_code, path, parent_path)
+
+    def update_term(self, taxonomy, term, changes):
+        return self.api.update_term(taxonomy, term, changes)
+
+    def delete_term(self, taxonomy, term):
+        self.api.delete_term(taxonomy, term)
+
 
     @cached_property
     def permission_factory(self):
@@ -33,6 +65,12 @@ class FlaskTaxonomies(object):
     def init_app(self, app, db=None):
         """Flask application initialization."""
         self.init_config(app)
+
+        # Connect signals
+        after_taxonomy_updated.connect(reindex_referencing_records)
+        after_taxonomy_term_moved.connect(reindex_referencing_records)
+        after_taxonomy_term_updated.connect(reindex_referencing_records)
+
         app.extensions['flask-taxonomies'] = _FlaskTaxonomiesState(app)
 
     def init_config(self, app):

--- a/flask_taxonomies/import_export/import_excel.py
+++ b/flask_taxonomies/import_export/import_excel.py
@@ -15,7 +15,6 @@ def import_taxonomy(taxonomy_file, int_conversions, str_args, drop):
     taxonomy_data, row = read_block(data, row)
 
     taxonomy = create_update_taxonomy(taxonomy_header, drop)
-
     create_update_terms(taxonomy, taxonomy_data, int_conversions, str_args)
 
 
@@ -28,7 +27,6 @@ def create_update_terms(taxonomy, taxonomy_data, int_conversions, str_args):
             stack.pop()
         if not slug:
             slug = slugify(next(filter(lambda x: x['lang'] == 'cs', term_dict['title']))['value'])
-
         term = taxonomy.get_term(slug)
         if term:
             term.update(term_dict)

--- a/flask_taxonomies/models.py
+++ b/flask_taxonomies/models.py
@@ -471,7 +471,7 @@ class TaxonomyTerm(db.Model):
 
     def __repr__(self):
         """Represent taxonomy term instance as a unique string."""
-        return "<TaxonomyTerm({slug}:{path})>" \
+        return "({slug}:{path})" \
             .format(slug=self.slug, path=self.id)
 
     @property

--- a/flask_taxonomies/signals.py
+++ b/flask_taxonomies/signals.py
@@ -26,10 +26,8 @@ def reindex_referencing_records(sender, taxonomy=None, term=None, *args, **kwarg
 def check_references_before_delete(sender, taxonomy=None, term=None, *args, **kwargs):
     records = []
     if taxonomy and not term:
-        # TODO: search for references of any term under a taxonomy
         records = current_oarepo_references.get_records(taxonomy.link_self)
     elif taxonomy and term:
-        # TODO: search for references of any term under a taxonomy
         links = current_flask_taxonomies.term_links(taxonomy.code, term.tree_path)
         records = current_oarepo_references.get_records(links['self'])
     if len(records) > 0:

--- a/flask_taxonomies/signals.py
+++ b/flask_taxonomies/signals.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Miroslav Bauer, CESNET.
+#
+# flask-taxonomies is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Taxonomy signal handlers"""
+
+from __future__ import absolute_import, print_function
+
+from werkzeug.exceptions import abort
+
+from flask_taxonomies.proxies import current_flask_taxonomies
+from oarepo_references.proxies import current_oarepo_references
+
+
+def reindex_referencing_records(sender, taxonomy=None, term=None, *args, **kwargs):
+    if taxonomy and not term:
+        current_oarepo_references.reindex_referencing_records(taxonomy.link_self)
+    elif taxonomy and term:
+        links = current_flask_taxonomies.term_links(taxonomy.code, term.tree_path)
+        current_oarepo_references.reindex_referencing_records(links['self'])
+
+
+def check_references_before_delete(sender, taxonomy=None, term=None, *args, **kwargs):
+    records = []
+    if taxonomy and not term:
+        # TODO: search for references of any term under a taxonomy
+        records = current_oarepo_references.get_records(taxonomy.link_self)
+    elif taxonomy and term:
+        # TODO: search for references of any term under a taxonomy
+        links = current_flask_taxonomies.term_links(taxonomy.code, term.tree_path)
+        records = current_oarepo_references.get_records(links['self'])
+    if len(records) > 0:
+        raise ReferenceError('Cannot Delete. Taxonomy is being referenced from some records.')

--- a/flask_taxonomies/signals.py
+++ b/flask_taxonomies/signals.py
@@ -9,8 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
-from werkzeug.exceptions import abort
-
+from flask_taxonomies.errors import TaxonomyDeleteError
 from flask_taxonomies.proxies import current_flask_taxonomies
 from oarepo_references.proxies import current_oarepo_references
 
@@ -31,4 +30,5 @@ def check_references_before_delete(sender, taxonomy=None, term=None, *args, **kw
         links = current_flask_taxonomies.term_links(taxonomy.code, term.tree_path)
         records = current_oarepo_references.get_records(links['self'])
     if len(records) > 0:
-        raise ReferenceError('Cannot Delete. Taxonomy is being referenced from some records.')
+        raise TaxonomyDeleteError(
+            'Cannot Delete. Taxonomy is being referenced from some records.', records)

--- a/flask_taxonomies/version.py
+++ b/flask_taxonomies/version.py
@@ -4,4 +4,4 @@
 
 from __future__ import absolute_import, print_function
 
-__version__ = '6.5.5'
+__version__ = '6.6.5'

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -12,6 +12,7 @@ from webargs import fields
 from webargs.flaskparser import parser, use_kwargs
 from werkzeug.exceptions import BadRequest
 
+from flask_taxonomies.errors import TaxonomyDeleteError
 from flask_taxonomies.flask_routing_ext import accept_fallback
 from flask_taxonomies.permissions import (
     permission_taxonomy_create_all,
@@ -407,8 +408,8 @@ def taxonomy_delete(taxonomy):
         response = make_response()
         response.status_code = 204
         return response
-    except ReferenceError as e:
-        abort(400, str(e))
+    except TaxonomyDeleteError as e:
+        abort(409, {'reason': str(e), 'records': e.records})
 
 
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("DELETE",))  # noqa
@@ -424,8 +425,8 @@ def taxonomy_delete_term(taxonomy, term):
         response = make_response()
         response.status_code = 204
         return response
-    except ReferenceError as e:
-        abort(400, str(e))
+    except TaxonomyDeleteError as e:
+        abort(409, {'reason': str(e), 'records': e.records})
 
 
 @blueprint.route("/<string:taxonomy_code>/", methods=("PATCH",))

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -4,10 +4,8 @@ from functools import wraps
 from typing import List
 from urllib.parse import urlsplit
 
-from flask import Blueprint, abort, current_app, jsonify, make_response, url_for
+from flask import Blueprint, abort, jsonify, make_response, url_for
 from flask_login import current_user
-from invenio_db import db
-from slugify import slugify
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from webargs import fields
@@ -15,30 +13,12 @@ from webargs.flaskparser import parser, use_kwargs
 from werkzeug.exceptions import BadRequest
 
 from flask_taxonomies.flask_routing_ext import accept_fallback
-from flask_taxonomies.models import (
-    MovePosition,
-    after_taxonomy_created,
-    after_taxonomy_deleted,
-    after_taxonomy_term_created,
-    after_taxonomy_term_deleted,
-    after_taxonomy_term_moved,
-    after_taxonomy_term_updated,
-    after_taxonomy_updated,
-    before_taxonomy_created,
-    before_taxonomy_deleted,
-    before_taxonomy_term_created,
-    before_taxonomy_term_deleted,
-    before_taxonomy_term_moved,
-    before_taxonomy_term_updated,
-    before_taxonomy_updated,
-)
 from flask_taxonomies.permissions import (
     permission_taxonomy_create_all,
     permission_taxonomy_read_all,
     permission_term_create_all,
 )
-from flask_taxonomies.proxies import current_permission_factory
-
+from flask_taxonomies.proxies import current_permission_factory, current_flask_taxonomies
 from .models import Taxonomy, TaxonomyTerm
 
 blueprint = Blueprint("taxonomies", __name__, url_prefix="/taxonomies")
@@ -189,57 +169,9 @@ def jsonify_taxonomy_term(t: TaxonomyTerm,
         "id": t.id,
         "slug": t.slug,
         "path": path,
-        "links": {
-            "self": url_for(
-                "taxonomies.taxonomy_get_term",
-                taxonomy_code=taxonomy_code,
-                term_path=path[1:],
-                _external=True,
-            ),
-            "tree": url_for(
-                "taxonomies.taxonomy_get_term",
-                taxonomy_code=taxonomy_code,
-                term_path=path[1:],
-                drilldown=True,
-                _external=True,
-            )
-        },
+        "links": current_flask_taxonomies.term_links(taxonomy_code, path, parent_path),
         "level": t.level - 1
     }
-    if parent_path is not None:
-        if parent_path != '':
-            txc = taxonomy_code + parent_path
-            txc = txc.split('/', maxsplit=1)
-            result['links'].update({
-                "parent": url_for(
-                    "taxonomies.taxonomy_get_term",
-                    taxonomy_code=txc[0],
-                    term_path=txc[1],
-                    _external=True,
-                ),
-                "parent_tree": url_for(
-                    "taxonomies.taxonomy_get_term",
-                    taxonomy_code=txc[0],
-                    term_path=txc[1],
-                    drilldown=True,
-                    _external=True,
-                )
-            })
-        else:
-            # parent is a taxonomy
-            result['links'].update({
-                "parent": url_for(
-                    "taxonomies.taxonomy_get_roots",
-                    taxonomy_code=taxonomy_code,
-                    _external=True,
-                ),
-                "parent_tree": url_for(
-                    "taxonomies.taxonomy_get_roots",
-                    taxonomy_code=taxonomy_code,
-                    drilldown=True,
-                    _external=True,
-                )
-            })
 
     if parents:
         result['ancestors'] = [*parents]
@@ -255,7 +187,7 @@ def jsonify_taxonomy_term(t: TaxonomyTerm,
 @permission_taxonomy_read_all.require(http_exception=403)
 def taxonomy_list():
     """List all available taxonomies."""
-    return jsonify([jsonify_taxonomy(t) for t in Taxonomy.taxonomies()])
+    return jsonify([jsonify_taxonomy(t) for t in current_flask_taxonomies.taxonomy_list()])
 
 
 @blueprint.route("/", methods=("POST",))
@@ -269,11 +201,7 @@ def taxonomy_list():
 def taxonomy_create(code: str, extra_data: dict = None):
     """Create a new Taxonomy."""
     try:
-        before_taxonomy_created.send(current_app._get_current_object(),
-                                     code=code, extra_data=extra_data)
-        created = Taxonomy.create_taxonomy(code=code, extra_data=extra_data)
-        db.session.commit()
-        after_taxonomy_created.send(created)
+        created = current_flask_taxonomies.create_taxonomy(code=code, extra_data=extra_data)
         created_dict = jsonify_taxonomy(created)
 
         response = jsonify(created_dict)
@@ -421,40 +349,26 @@ def taxonomy_create_child_term(taxonomy, slug=None, term_path='', extra_data=Non
 )
 def taxonomy_move_term(taxonomy, term_path='', destination='', destination_order=''):
     """Create a Term inside a Taxonomy tree."""
+    target_path = None
     if not destination:
         abort(400, "No destination given.")
 
-    term = taxonomy.find_term(term_path)
-    if not term:
-        abort(400, "Invalid Term path given.")
-
-    target_path = None
-
     try:
         target_path = url_to_path(destination)
-        before_taxonomy_term_moved.send(
-            term, taxonomy=taxonomy,
-            target_path=target_path, order=destination_order)
     except ValueError:
         abort(400, 'Invalid target URL passed.')
 
-    if not target_path:
-        target_path = f'{taxonomy.code}/'
-
     try:
-        target_taxonomy, target_term = Taxonomy.find_taxonomy_and_term(target_path)
+        term, target_taxonomy, target_term = current_flask_taxonomies.move_term(
+            taxonomy, term_path, target_path, destination_order)
+        moved = jsonify_taxonomy_term(term, target_taxonomy.code, term.tree_path)
+        response = jsonify(moved)
+        response.headers['Location'] = moved['links']['self']
+        return response
+    except AttributeError as e:
+        abort(400, e)
     except NoResultFound:
         abort(400, "Target path not found.")
-
-    term.move(target_term, position=MovePosition(destination_order or 'inside'))
-    db.session.commit()
-
-    after_taxonomy_term_moved.send(term, taxonomy=taxonomy)
-    db.session.refresh(term)
-    moved = jsonify_taxonomy_term(term, target_taxonomy.code, term.tree_path)
-    response = jsonify(moved)
-    response.headers['Location'] = moved['links']['self']
-    return response
 
 
 def _taxonomy_create_term_internal(taxonomy, slug=None,
@@ -463,26 +377,20 @@ def _taxonomy_create_term_internal(taxonomy, slug=None,
     if not slug:
         abort(400, "No slug given for created element.")
 
-    term = taxonomy.find_term(term_path)
-    if not term:
-        abort(400, "Invalid Term path given.")
-
     try:
-        slug = slugify(slug)
-        before_taxonomy_term_created.send(taxonomy, slug=slug, extra_data=extra_data)
-        created = term.create_term(slug=slug, extra_data=extra_data)
-        db.session.commit()
-        after_taxonomy_term_created.send(term, taxonomy=taxonomy)
-
+        created = current_flask_taxonomies.create_term(taxonomy=taxonomy,
+                                                       term_path=term_path,
+                                                       slug=slug,
+                                                       extra_data=extra_data)
         created_dict = \
             jsonify_taxonomy_term(created, taxonomy.code, created.tree_path)
-
         response = jsonify(created_dict)
         response.headers['Location'] = created_dict['links']['self']
         response.status_code = 201
         return response
+    except AttributeError as e:
+        abort(400, e)
     except IntegrityError:
-        db.session.rollback()
         abort(400, 'Term with this slug already exists on this path.')
 
 
@@ -494,13 +402,13 @@ def _taxonomy_create_term_internal(taxonomy, slug=None,
 )
 def taxonomy_delete(taxonomy):
     """Delete whole taxonomy tree."""
-    before_taxonomy_deleted.send(taxonomy)
-    taxonomy.delete()
-    db.session.commit()
-    after_taxonomy_deleted.send(taxonomy)
-    response = make_response()
-    response.status_code = 204
-    return response
+    try:
+        current_flask_taxonomies.delete_taxonomy(taxonomy)
+        response = make_response()
+        response.status_code = 204
+        return response
+    except ReferenceError as e:
+        abort(400, e)
 
 
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("DELETE",))  # noqa
@@ -511,13 +419,13 @@ def taxonomy_delete(taxonomy):
 )
 def taxonomy_delete_term(taxonomy, term):
     """Delete a Term subtree in a Taxonomy."""
-    before_taxonomy_term_deleted.send(term, taxonomy=taxonomy)
-    term.delete()
-    db.session.commit()
-    after_taxonomy_term_deleted.send(term, taxonomy=taxonomy)
-    response = make_response()
-    response.status_code = 204
-    return response
+    try:
+        current_flask_taxonomies.delete_term(taxonomy, term)
+        response = make_response()
+        response.status_code = 204
+        return response
+    except ReferenceError as e:
+        abort(400, e)
 
 
 @blueprint.route("/<string:taxonomy_code>/", methods=("PATCH",))
@@ -531,10 +439,7 @@ def taxonomy_delete_term(taxonomy, term):
 )
 def taxonomy_update(taxonomy, extra_data):
     """Update Taxonomy."""
-    before_taxonomy_updated.send(taxonomy, extra_data=extra_data)
-    taxonomy.update(extra_data)
-    db.session.commit()
-    after_taxonomy_updated.send(taxonomy)
+    taxonomy = current_flask_taxonomies.update_taxonomy(taxonomy, extra_data)
 
     return jsonify(jsonify_taxonomy(taxonomy))
 
@@ -556,10 +461,7 @@ def taxonomy_update_term(taxonomy, term, extra_data=None):
     if extra_data:
         changes["extra_data"] = extra_data
 
-    before_taxonomy_term_updated.send(term, taxonomy=taxonomy, extra_data=extra_data)
-    term.update(**changes)
-    db.session.commit()
-    after_taxonomy_term_updated.send(term, taxonomy=taxonomy)
+    term = current_flask_taxonomies.update_term(taxonomy, term, changes)
 
     return jsonify(
         jsonify_taxonomy_term(term, taxonomy.code, term.tree_path),

--- a/flask_taxonomies/views.py
+++ b/flask_taxonomies/views.py
@@ -366,7 +366,7 @@ def taxonomy_move_term(taxonomy, term_path='', destination='', destination_order
         response.headers['Location'] = moved['links']['self']
         return response
     except AttributeError as e:
-        abort(400, e)
+        abort(400, str(e))
     except NoResultFound:
         abort(400, "Target path not found.")
 
@@ -389,7 +389,7 @@ def _taxonomy_create_term_internal(taxonomy, slug=None,
         response.status_code = 201
         return response
     except AttributeError as e:
-        abort(400, e)
+        abort(400, str(e))
     except IntegrityError:
         abort(400, 'Term with this slug already exists on this path.')
 
@@ -408,7 +408,7 @@ def taxonomy_delete(taxonomy):
         response.status_code = 204
         return response
     except ReferenceError as e:
-        abort(400, e)
+        abort(400, str(e))
 
 
 @blueprint.route("/<string:taxonomy_code>/<path:term_path>/", methods=("DELETE",))  # noqa
@@ -425,7 +425,7 @@ def taxonomy_delete_term(taxonomy, term):
         response.status_code = 204
         return response
     except ReferenceError as e:
-        abort(400, e)
+        abort(400, str(e))
 
 
 @blueprint.route("/<string:taxonomy_code>/", methods=("PATCH",))

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     'python-slugify>=3.0.2',
     'webargs>=5.3.2',
     'wrapt>=1.11.0',
+    'oarepo-references>=1.0.0'
 ]
 
 tests_require = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,13 @@ from flask_taxonomies.permissions import (
     taxonomy_update_all,
 )
 from flask_taxonomies.views import blueprint
+from oarepo_references import OARepoReferences
+from oarepo_references.ext import _RecordReferencesState
+
+
+class RecordReferencesStateMock(_RecordReferencesState):
+    def reindex_referencing_records(self, reference):
+        print('reindexing records for: {}'.format(reference))
 
 
 class JsonClient(FlaskClient):
@@ -61,6 +68,8 @@ def base_app():
     InvenioAccounts(app_)
     InvenioAccess(app_)
     InvenioJSONSchemas(app_)
+    OARepoReferences(app_)
+    app_.extensions['oarepo-references'] = RecordReferencesStateMock(app_)
 
     return app_
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Model unit tests."""
+import pytest
+
+from flask_taxonomies.models import MovePosition, TaxonomyError
+from flask_taxonomies.proxies import current_flask_taxonomies
+
+
+@pytest.mark.usefixtures("db")
+class TestTaxonomyAPI:
+    """Taxonomy model tests."""
+
+    def test_create(self, db, Taxonomy, TaxonomyTerm):
+        """Test create taxonomy."""
+        tax = current_flask_taxonomies.create_taxonomy('code', {'extra': 'data'})
+        db.session.add(tax)
+        db.session.commit()
+
+        retrieved = Taxonomy(TaxonomyTerm.query.get(tax.id))
+        assert retrieved.code == "code"
+        assert retrieved.extra_data == {"extra": "data"}
+
+        tax.check()
+
+    def test_taxonomy_list(self, db, root_taxonomy, mkt):
+        """Get terms  listassocitated with this taxonomy."""
+        taxos = list(current_flask_taxonomies.taxonomy_list())
+
+        assert len(taxos) == 1
+        assert taxos[0] == root_taxonomy
+
+        root_taxonomy.check()
+
+    def test_update_taxonomy(self, db, root_taxonomy, TaxonomyTerm):
+        """Update Taxonomy extra_data."""
+        current_flask_taxonomies.update_taxonomy(root_taxonomy, {"description": "updated"})
+
+        retrieved_root = TaxonomyTerm.query.get(root_taxonomy.id)
+        assert retrieved_root.extra_data == {"description": "updated"}
+
+        root_taxonomy.check()
+
+    def test_delete_taxonomy(self, db, root_taxonomy, TaxonomyTerm):
+        """Test deleting the whole Taxonomy."""
+
+        leaf = root_taxonomy.create_term(slug="leaf")
+        nested = leaf.create_term(slug="nested")
+
+        root_taxonomy.check()
+
+        current_flask_taxonomies.delete_taxonomy(root_taxonomy)
+
+        assert TaxonomyTerm.query.get(root_taxonomy.id) is None
+        assert TaxonomyTerm.query.get(leaf.id) is None
+        assert TaxonomyTerm.query.get(nested.id) is None
+
+
+@pytest.mark.usefixtures("db")
+class TestTaxonomyTerm:
+    """TaxonomyTerm model tests."""
+
+    def test_update_taxonomy_term(self, db, root_taxonomy, TaxonomyTerm):
+        """Update TaxonomyTerm extra_data and name."""
+        leaf = root_taxonomy.create_term(slug="leaf")
+
+        current_flask_taxonomies.update_term(root_taxonomy, leaf,
+                                             {'extra_data': {"description": "updated"}})
+
+        retrieved_root = TaxonomyTerm.query.get(leaf.id)
+        assert retrieved_root.extra_data == {"description": "updated"}
+
+        root_taxonomy.check()
+
+    def test_delete_taxonomy_term(self, db, root_taxonomy, TaxonomyTerm, mkt):
+        """Delete single TaxonomyTerm term."""
+        leaf = root_taxonomy.create_term(slug="leaf")
+        root_taxonomy.create_term(slug="leaf2")
+
+        assert list(root_taxonomy.dump()) == mkt('leaf', 'leaf2')
+
+        root_taxonomy.check()
+
+        current_flask_taxonomies.delete_term(root_taxonomy, leaf)
+
+        assert TaxonomyTerm.query.get(leaf.id) is None
+
+        assert list(root_taxonomy.dump()) == mkt('leaf2')
+
+        root_taxonomy.check()
+
+    def test_move_taxonomy_term_inside(self, db, root_taxonomy, mkt):
+        t1 = root_taxonomy.create_term(slug="leaf1")
+        t2 = root_taxonomy.create_term(slug="leaf2")
+
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                           destination_order=MovePosition.INSIDE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf2', 'leaf1')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t2.tree_path,
+                                           destination_order=MovePosition.INSIDE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2')
+
+    def test_move_taxonomy_term_with_children_inside(self, db, root_taxonomy, mkt):
+        t1 = root_taxonomy.create_term(slug="leaf1")
+        t1.create_term(slug="leaf11")
+        t1.create_term(slug="leaf12")
+        t2 = root_taxonomy.create_term(slug="leaf2")
+        t2.create_term(slug="leaf21")
+        t2.create_term(slug="leaf22")
+
+        root_taxonomy.check()
+        print(mkt(
+            ('leaf1',
+             'leaf11', 'leaf12'),
+            ('leaf2',
+             'leaf21', 'leaf22')))
+        assert list(root_taxonomy.dump()) == mkt(
+            ('leaf1',
+             'leaf11', 'leaf12'),
+            ('leaf2',
+             'leaf21', 'leaf22'))
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                           destination_order=MovePosition.INSIDE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt(
+            ('leaf2',
+             'leaf21', 'leaf22'),
+            ('leaf1',
+             'leaf11', 'leaf12'),
+        )
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t2.tree_path,
+                                           destination_order=MovePosition.INSIDE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt(
+            ('leaf1',
+             'leaf11', 'leaf12'),
+            ('leaf2',
+             'leaf21', 'leaf22'))
+
+    def test_move_taxonomy_term_before(self, db, root_taxonomy, mkt):
+        t1 = root_taxonomy.create_term(slug="leaf1")
+        t2 = root_taxonomy.create_term(slug="leaf2")
+        t3 = root_taxonomy.create_term(slug="leaf3")
+
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2', 'leaf3')
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t2.tree_path,
+                                           target_path=root_taxonomy.code + t1.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf2', 'leaf1', 'leaf3')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                           target_path=root_taxonomy.code + t2.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2', 'leaf3')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                           target_path=root_taxonomy.code + t3.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf2', 'leaf1', 'leaf3')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t3.tree_path,
+                                           target_path=root_taxonomy.code + t1.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf2', 'leaf3', 'leaf1')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t3.tree_path,
+                                           target_path=root_taxonomy.code + t2.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf3', 'leaf2', 'leaf1')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                           target_path=root_taxonomy.code + t3.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf3', 'leaf2')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t2.tree_path,
+                                           target_path=root_taxonomy.code + t3.tree_path,
+                                           destination_order=MovePosition.BEFORE)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2', 'leaf3')
+
+    def test_move_taxonomy_term_after(self, db, root_taxonomy, mkt):
+        t1 = root_taxonomy.create_term(slug="leaf1")
+        t2 = root_taxonomy.create_term(slug="leaf2")
+        t3 = root_taxonomy.create_term(slug="leaf3")
+
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2', 'leaf3')
+
+        current_flask_taxonomies.move_term(root_taxonomy, term_path=t2.tree_path,
+                                           target_path=root_taxonomy.code + t1.tree_path,
+                                           destination_order=MovePosition.AFTER)
+        root_taxonomy.check()
+        assert list(root_taxonomy.dump()) == mkt('leaf1', 'leaf2', 'leaf3')
+
+    def test_move_taxonomy_prohibited(self, db, root_taxonomy, mkt):
+        t1 = root_taxonomy.create_term(slug="1")
+        t11 = t1.create_term(slug="11")
+        t12 = t1.create_term(slug="12")
+
+        with pytest.raises(TaxonomyError,
+                           match='Can not move term inside, before or after the same term'):
+            current_flask_taxonomies.move_term(root_taxonomy, term_path=t1.tree_path,
+                                               target_path=root_taxonomy.code + t1.tree_path,
+                                               destination_order=MovePosition.INSIDE)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Model unit tests."""
 import pytest
-from sqlalchemy import and_
 
 from flask_taxonomies.models import MovePosition, TaxonomyError
 
@@ -41,7 +40,6 @@ class TestTaxonomy:
 
     def test_update_taxonomy(self, db, root_taxonomy, TaxonomyTerm):
         """Update Taxonomy extra_data."""
-
         root_taxonomy.update(extra_data={"description": "updated"})
 
         retrieved_root = TaxonomyTerm.query.get(root_taxonomy.id)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,7 +30,7 @@ if False:
 
 
 @pytest.mark.usefixtures("db")
-class TestTaxonomyAPI:
+class TestTaxonomyViews:
     """TaxonomyTerm functional test."""
 
     def test_list_taxonomies(self, db, client, root_taxonomy, Taxonomy, permissions):


### PR DESCRIPTION
This pull moves refactors all major Taxonomy and TaxonomyTerm operations
to a dedicated API that is accessible through a LocalProxy reference.

Integration with oarepo-references module is added to call reference-update
hooks whenever a taxonomy changes.