### PR TITLE
Added new conf parameter TAXONOMIES_REF_HOST

### DIFF
--- a/flask_taxonomies/jsonresolver.py
+++ b/flask_taxonomies/jsonresolver.py
@@ -31,10 +31,16 @@ def jsonresolver_loader(url_map):
         endpoint=get_taxonomy_term,
         host=current_app.config.get('SERVER_NAME')
     ))
+    taxonomy_ref_host = current_app.config.get('TAXONOMIES_REF_HOST')
+    if taxonomy_ref_host is not None:
+        url_map.add(Rule(
+            "/api/taxonomies/<string:code>/<path:slug>",
+            endpoint=get_taxonomy_term,
+            host=taxonomy_ref_host
+        ))
 
 
 def get_taxonomy_term(code=None, slug=None):
-
     try:
         taxonomy = Taxonomy.get(code)
         term = taxonomy.find_term(slug)


### PR DESCRIPTION
If database is dumped and restored from another host, the references contain the name of the source host. This commit enable get taxonomies from the remote server.