### PR TITLE
Added link_self function

### DIFF
--- a/flask_taxonomies/utils.py
+++ b/flask_taxonomies/utils.py
@@ -5,7 +5,7 @@ import json
 import six
 import sqlalchemy
 from flask import current_app
-from werkzeug.utils import import_string
+from werkzeug.utils import cached_property, import_string
 
 from flask_taxonomies.models import TaxonomyTerm
 
@@ -67,6 +67,28 @@ def find_in_json_contains(search_term: str, taxonomy, tree_address="aliases"):
         contains(search_term)
     query = taxonomy.descendants.filter(expr)
     return query
+
+
+class Constants:
+    @cached_property
+    def server_name(self):
+        return current_app.config.get('SERVER_NAME')
+
+
+constants = Constants()
+
+
+def link_self(taxonomy_code, taxonomy_term):
+    """
+    Function returns reference to the taxonomy from taxonomy code and taxonomy term.
+    :param taxonomy_code:
+    :param taxonomy_term:
+    :return:
+    """
+    SERVER_NAME = constants.server_name
+    base = f"https://{SERVER_NAME}/api/taxonomies"
+    path = [base, taxonomy_code + "/" + taxonomy_term.slug]
+    return "/".join(path)
 
 
 if marshmallow_version[0] >= 3:

--- a/tests/test_link_self.py
+++ b/tests/test_link_self.py
@@ -1,0 +1,11 @@
+from flask_taxonomies.utils import link_self
+
+
+def test_link_self(db, root_taxonomy):
+    leaf = root_taxonomy.create_term(slug="leaf",
+                                     extra_data="extra_data")
+
+    db.session.refresh(root_taxonomy)
+    db.session.refresh(leaf)
+
+    assert link_self("root", leaf) == "https://localhost/api/taxonomies/root/leaf"


### PR DESCRIPTION
link_self is function located in utils.py that takes two arguments, taxonomy_code (string) and taxonomy_term instance and return taxonomy URL at the current server from current_app.config.