### PR TITLE
Fixed bug #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,12 +1110,15 @@ $ curl -i 'http://127.0.0.1:5000/api/2.0/taxonomies/test/term/nested'
 
 HTTP/1.0 301 MOVED PERMANENTLY
 Location: http://127.0.0.1:5000/api/2.0/taxonomies/test/nested
+Link: <http://localhost/api/2.0/taxonomies/test/term/nested>; rel=self
+Link: <http://localhost/api/2.0/taxonomies/test/nested>; rel=obsoleted_by
 
 {
     "links": {
-        "self": "http://127.0.0.1:5000/api/2.0/taxonomies/test/nested"
+        "self": "http://localhost/api/2.0/taxonomies/test/term/nested", 
+        "obsoleted_by": "http://localhost/api/2.0/taxonomies/test/nested"
     }, 
-    "status": "deleted"
+    "status": "moved"
 }
 ```
 
@@ -1147,12 +1150,15 @@ $ curl -i 'http://127.0.0.1:5000/api/2.0/taxonomies/test/nested'
 
 HTTP/1.0 301 MOVED PERMANENTLY
 Location: http://127.0.0.1:5000/api/2.0/taxonomies/test/renamed-nested
+Link: <http://localhost/api/2.0/taxonomies/test/nested>; rel=self
+Link: <http://localhost/api/2.0/taxonomies/test/renamed-nested>; rel=obsoleted_by
 
 {
     "links": {
-        "self": "http://127.0.0.1:5000/api/2.0/taxonomies/test/renamed-nested"
+        "self": "http://localhost/api/2.0/taxonomies/test/nested", 
+        "obsoleted_by": "http://localhost/api/2.0/taxonomies/test/renamed-nested"
     }, 
-    "status": "deleted"
+    "status": "moved"
 }
 ```
 

--- a/tests/test_rest_move_term.py
+++ b/tests/test_rest_move_term.py
@@ -1,5 +1,13 @@
 import json
 
+from link_header import parse, LinkHeader, Link
+
+
+def links2dict(links):
+    return {
+        l.rel: l.href for l in links.links
+    }
+
 
 def term_move_to_root_test(api, client, sample_taxonomy):
     resp = client.post('/api/2.0/taxonomies/test/a/aa', headers={
@@ -20,9 +28,17 @@ def term_move_to_root_test(api, client, sample_taxonomy):
     resp = client.get('/api/2.0/taxonomies/test/a/aa')
     assert resp.status_code == 301
     assert resp.headers['Location'] == 'http://localhost/api/2.0/taxonomies/test/aa'
+    links = parse(resp.headers['Link'])
+    assert links2dict(links) == {
+        'self': 'http://localhost/api/2.0/taxonomies/test/a/aa',
+        'obsoleted_by': 'http://localhost/api/2.0/taxonomies/test/aa'
+    }
     assert resp.json == {
-        'links': {'self': 'http://localhost/api/2.0/taxonomies/test/aa'},
-        'status': 'deleted'
+        'links': {
+            'obsoleted_by': 'http://localhost/api/2.0/taxonomies/test/aa',
+            'self': 'http://localhost/api/2.0/taxonomies/test/a/aa'
+        },
+        'status': 'moved'
     }
 
 
@@ -52,6 +68,9 @@ def term_move_to_element_test(api, client, sample_taxonomy):
     assert resp.status_code == 301
     assert resp.headers['Location'] == 'http://localhost/api/2.0/taxonomies/test/a/b'
     assert resp.json == {
-        'links': {'self': 'http://localhost/api/2.0/taxonomies/test/a/b'},
-        'status': 'deleted'
+        'links': {
+            'obsoleted_by': 'http://localhost/api/2.0/taxonomies/test/a/b',
+            'self': 'http://localhost/api/2.0/taxonomies/test/b'
+        },
+        'status': 'moved'
     }


### PR DESCRIPTION
Moved term returns correct metadata, not deleted:

```console
$ curl -i 'http://127.0.0.1:5000/api/2.0/taxonomies/test/term/nested'

HTTP/1.0 301 MOVED PERMANENTLY
Location: http://127.0.0.1:5000/api/2.0/taxonomies/test/nested
Link: <http://localhost/api/2.0/taxonomies/test/term/nested>; rel=self
Link: <http://localhost/api/2.0/taxonomies/test/nested>; rel=obsoleted_by

{
    "links": {
        "self": "http://localhost/api/2.0/taxonomies/test/term/nested", 
        "obsoleted_by": "http://localhost/api/2.0/taxonomies/test/nested"
    }, 
    "status": "moved"
}
```